### PR TITLE
setup.php php 8.1 deprecation for function_exists(): Passing null to parameter

### DIFF
--- a/www/setup/setup.php
+++ b/www/setup/setup.php
@@ -101,7 +101,7 @@
 		unset($_POST['_ACTION']);
 		unset($_POST['_SUBMIT']);
 
-		$error = ((function_exists($action)) ? $action() : '');
+		$error = ((function_exists($action ?? '')) ? $action() : '');
 		if($configfile=='')  $error .= "<br>'configfile' for this step is missing";
 
 		if($error=='') {


### PR DESCRIPTION
php 8.1 deprecation for function_exists(): Passing null to parameter