### PR TITLE
Error Service "SystemConfigModule" was not found when run on windows

### DIFF
--- a/classes/Core/Installer/Psr4ClassNameResolver.php
+++ b/classes/Core/Installer/Psr4ClassNameResolver.php
@@ -35,7 +35,7 @@ final class Psr4ClassNameResolver
     {
         // Normalize inputs
         $prefix = trim($prefix, '\\') . '\\';
-        $baseDir = rtrim($baseDir, '/') . '/';
+        $baseDir = rtrim($baseDir, '/\\') . DIRECTORY_SEPARATOR;
 
         $this->prefixes[$prefix] = $baseDir;
     }

--- a/classes/bootstrap.php
+++ b/classes/bootstrap.php
@@ -30,10 +30,10 @@ $factoryServiceMap = @include $serviceCacheFile;
 
 if (!is_file($serviceCacheFile)) {
 
-    // Installer ausführen wenn ServiceMap nicht vorhanden ist
+    // Installer ausführen, wenn ServiceMap nicht vorhanden ist
     $resolver = new Psr4ClassNameResolver();
     $resolver->addNamespace('Xentral\\', __DIR__);
-    $resolver->excludeFile(__DIR__ . '/bootstrap.php');
+    $resolver->excludeFile(__DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php');
 
     $generator = new ClassMapGenerator($resolver, __DIR__);
     $installer = new Installer($generator, $resolver);


### PR DESCRIPTION
`classes/bootstrap.php` is unable to compile the service cache file. This is due to inconsistent use of directory separator (forwardslash vs. backslash).