### PR TITLE
Logfile::addLogFile() does not escape the given parameters

### DIFF
--- a/www/pages/logfile.php
+++ b/www/pages/logfile.php
@@ -254,11 +254,14 @@ class Logfile {
       }
     }
     if(is_array($meldung)) {
-      $meldung = $this->app->DB->real_escape_string(print_r($meldung, true));
+      $meldung = print_r($meldung, true);
     }
     
-    // Quick fix
-    $dump = $this->app->DB->real_escape_string(print_r($dump, true));
+    $module = $this->app->DB->real_escape_string($module);
+    $action = $this->app->DB->real_escape_string($action);
+    $meldung = $this->app->DB->real_escape_string($meldung);
+    $dump = $this->app->DB->real_escape_string($dump);
+    $functionname = $this->app->DB->real_escape_string($functionname);
     
     $this->app->DB->Insert(
       sprintf(

--- a/www/pages/logfile.php
+++ b/www/pages/logfile.php
@@ -256,6 +256,10 @@ class Logfile {
     if(is_array($meldung)) {
       $meldung = $this->app->DB->real_escape_string(print_r($meldung, true));
     }
+    
+    // Quick fix
+    $dump = $this->app->DB->real_escape_string(print_r($dump, true));
+    
     $this->app->DB->Insert(
       sprintf(
         "INSERT INTO logfile (module,action,meldung,dump,datum,bearbeiter,funktionsname)

--- a/www/pages/logfile.php
+++ b/www/pages/logfile.php
@@ -253,15 +253,12 @@ class Logfile {
         }
       }
     }
-    if(is_array($meldung)) {
-      $meldung = print_r($meldung, true);
-    }
     
-    $module = $this->app->DB->real_escape_string($module);
-    $action = $this->app->DB->real_escape_string($action);
-    $meldung = $this->app->DB->real_escape_string($meldung);
-    $dump = $this->app->DB->real_escape_string($dump);
-    $functionname = $this->app->DB->real_escape_string($functionname);
+    $module = $this->app->DB->real_escape_string(is_scalar($module) ? strval($module) : print_r($module, true));
+    $action = $this->app->DB->real_escape_string(is_scalar($action) ? strval($action) : print_r($action, true));
+    $meldung = $this->app->DB->real_escape_string(is_scalar($meldung) ? strval($meldung) : print_r($meldung, true));
+    $dump = $this->app->DB->real_escape_string(is_scalar($dump) ? strval($dump) : print_r($dump, true));
+    $functionname = $this->app->DB->real_escape_string(is_scalar($functionname) ? strval($functionname) : print_r($functionname, true));
     
     $this->app->DB->Insert(
       sprintf(


### PR DESCRIPTION
All the parameters should be escaped to prevent SQL injection. Also some calls give arrays in the parameters, so checking for scalar value and using print_r if not.