### PR TITLE
Make Shopware-Lib compatible with 6.x

### DIFF
--- a/classes/Modules/Shopware6/Client/Shopware6Client.php
+++ b/classes/Modules/Shopware6/Client/Shopware6Client.php
@@ -73,7 +73,7 @@ final class Shopware6Client
 
         $request = new ClientRequest(
             $method,
-            $this->url . 'v2/' . $endpoint,
+            $this->url . $endpoint,
             $headerInformation,
             empty($body) ? null : json_encode($body)
         );

--- a/www/lib/class.erpapi.php
+++ b/www/lib/class.erpapi.php
@@ -22527,7 +22527,7 @@ function ChargenMHDAuslagern($artikel, $menge, $lagerplatztyp, $lpid,$typ,$wert,
         $pseudolager = !empty($shopAricleArr['pseudolager'])?(float)$shopAricleArr['pseudolager']:0;
       }
       else {
-        $pseudolager = '';
+        $pseudolager = 0;
       }
       $this->app->erp->RunHook('remote_send_article_list_pseudostorage', 3, $shop, $artikelid, $pseudolager);
       if(is_numeric($pseudolager) && $pseudolager < 0) {


### PR DESCRIPTION
We should at least add a Upgrade-Notice for Users that they might have to add "v2" in the URL of their Shop-Settings