### PR TITLE
Fehler bei Änderung des Rabatts in der ersten Zeile von Angeboten, Rechnungen, etc.

### DIFF
--- a/phpwf/plugins/class.yui.php
+++ b/phpwf/plugins/class.yui.php
@@ -736,9 +736,10 @@ class YUI {
             if($value == '')$value = '0';
             $this->app->DB->Update("UPDATE $table SET rabatt='$value',keinrabatterlaubt=1 WHERE id='$id' LIMIT 1");
             $result = $this->app->DB->Select("SELECT ".$this->FormatPreis('rabatt')." FROM $table WHERE id='$id' LIMIT 1");
-            $sort = $this->app->DB->Select("SELECT sort FROM $table WHERE id='$id' LIMIT 1");
-            $parent = $this->app->DB->Select("SELECT $module FROM $table WHERE id='$id' LIMIT 1");
-            if($parent && $sort == 1)$this->app->DB->Update("UPDATE $module SET rabatt = '$value',keinrabatterlaubt=1 WHERE id = '$parent' LIMIT 1");
+
+            //$sort = $this->app->DB->Select("SELECT sort FROM $table WHERE id='$id' LIMIT 1");
+            //$parent = $this->app->DB->Select("SELECT $module FROM $table WHERE id='$id' LIMIT 1");
+            //if($parent && $sort == 1)$this->app->DB->Update("UPDATE $module SET rabatt = '$value',keinrabatterlaubt=1 WHERE id = '$parent' LIMIT 1");
             if(in_array($module, array('auftrag','rechnung','gutschrift')))
             {
               $tmptable_value = $this->app->DB->Select("SELECT $module FROM $table WHERE id = '$id' LIMIT 1");


### PR DESCRIPTION
An Angeboten, Rechnungen, etc. lässt sich der Rabatt in der ersten Zeile nicht ändern, der Server liefert einen Fehler 500 weil ein Mysql Query versucht, in der Rechnungstabelle "keinrabatterlaubt" zu setzen.

Der ganze Code ist mir ein Rätsel, ich wüsste nicht, wofür der gut sein könnte. Bei mir funktioniert es ohne diese 3 Zeilen.