### PR TITLE
Fix Typo

### DIFF
--- a/www/devices/index.php
+++ b/www/devices/index.php
@@ -22,7 +22,7 @@ include '../lib/libextern.php';
 
 
 $config = new Config();
-$db = new DB($config->WFdbhost, $config->WFdbname, $config->WFdbuser, $config->WFdbpass,null,$conf->WFdbport);
+$db = new DB($config->WFdbhost, $config->WFdbname, $config->WFdbuser, $config->WFdbpass,null,$config->WFdbport);
 //$erp = new erpAPI($app);
 //$app->erp = $erp;
 


### PR DESCRIPTION
Wenn der Printerspooler auf Windows läuft und periodisch die Warteschlange abfragt ensteht im error_log jedesmal eine neue Meldung:
 
Got error 'PHP message: PHP Warning:  Undefined variable $conf in /openxe/www/devices/index.php on line 25; PHP message: PHP Warning:  Attempt to read property "WFdbport" on null in /openxe/www/devices/index.php on line 25'