### PR TITLE
Bugfix Cronjob shopimport error with PHP8.1

### DIFF
--- a/cronjobs/shopimport.php
+++ b/cronjobs/shopimport.php
@@ -945,7 +945,7 @@ if($shops) {
               {
                 $onlinebestellnummer = $tmpwarenkorb['auftrag'];
               }
-              $projekt = $app->DB->Select("SELECT projekt WHERE shopexport = '$id' LIMIT 1");
+              //$projekt = $app->DB->Select("SELECT projekt WHERE shopexport = '$id' LIMIT 1");
               if(!empty($tmpwarenkorb['projekt']) && $app->DB->Select("SELECT id FROM projekt WHERE id = '".(int)$tmpwarenkorb['projekt']."' LIMIT 1"))$projekt = (int)$tmpwarenkorb['projekt'];
               if(isset($tmpwarenkorb['subshop']) && $tmpwarenkorb['subshop'])
               {


### PR DESCRIPTION
Invalid SQL leads to fatal error with PHP8.1, has been silently skipped with PHP8.0.
$projekt is already set before, so the line can most likely be removed completely