### PR TITLE
wareneingang: optionally hide non storage articles

### DIFF
--- a/www/pages/content/firmendaten.tpl
+++ b/www/pages/content/firmendaten.tpl
@@ -1287,6 +1287,7 @@
 							<tr><td>Auftr&auml;ge zu Bestellungen im Wareneingang anzeigen:</td><td><input type="checkbox" name="wareneingangauftragzubestellung" [WARENEINGANGAUFTRAGZUBESTELLUNG]></td></tr>
 							<tr><td>{|Bildtyp beim Upload im Wareneingang|}:</td><td><select name="wareneingangbildtypvorauswahl" id="wareneingangbildtypvorauswahl">[WARENEINGANBILDTYPVORAUSWAHL]</select></td></tr>
 							<tr><td>{|Verhalten beim Scannen im Wareneingang|}:</td><td><select name="wareneingangscanverhalten" id="wareneingangscanverhalten">[WARENEINGANGSCANVERHALTENAUSWAHL]</select></td></tr>
+							<tr><td>Nur Lagerartikel im Wareneingang:</td><td><input type="checkbox" name="wareneingang_lagerartikel" [WARENEINGANG_LAGERARTIKEL]> </td></tr>
 						</table>
 					</fieldset>
 				</div>

--- a/www/pages/wareneingang.php
+++ b/www/pages/wareneingang.php
@@ -350,7 +350,11 @@ class Wareneingang {
 
 //                $menu = "<table cellpadding=0 cellspacing=0><tr><td nowrap>Menge:&nbsp;<input type=\"text\" size=\"5\" name=\"pos[%value%]\">&nbsp;</td></tr></table>";
                 $menucol = 4;
-                $lagerartikel = "";
+                if($this->app->erp->Firmendaten("wareneingang_lagerartikel")) {
+                    $lagerartikel = "AND art.lagerartikel = 1";
+                } else {
+                    $lagerartikel = "";
+                }
                 $receiptDocument = $this->app->erp->ModulVorhanden('receiptdocument');
                 if ($receiptDocument) {
                     $this->app->DB->Select('SELECT id FROM receiptdocument LIMIT 1');


### PR DESCRIPTION
We have non storage articles in Bestellungen such as delivery costs. They appear in Wareneingang but should not be booked into storage. This commit makes visibility of such articles optionally.