### PR TITLE
fix sorting/search for buchungen and kontoauszuege

### DIFF
--- a/www/pages/fibu_buchungen.php
+++ b/www/pages/fibu_buchungen.php
@@ -273,7 +273,7 @@ class Fibu_buchungen {
                             '' AS dummy,
                             '' AS dummy2,
                             auswahl,
-                            datum,
+                            ".$this->app->erp->FormatDate(" datum ").",
                             ".$this->app->erp->FormatUCfirst("typ").",
                             objektlink,
                             saldo,
@@ -308,7 +308,7 @@ class Fibu_buchungen {
                             FROM
                                 (
                                 SELECT
-                                    ".$this->app->erp->FormatDate(" fb.datum ")." AS datum,
+                                    fb.datum,
                                     fb.typ,
                                     fb.id,
                                     fo.info,

--- a/www/pages/kontoauszuege.php
+++ b/www/pages/kontoauszuege.php
@@ -120,8 +120,8 @@ class Kontoauszuege {
 
                 $sumcol = array(10);
 
-                $findcols = array('q.id','q.id','q.kurzbezeichnung', 'q.importdatum', 'q.buchung', 'q.soll', 'q.waehrung', 'q.buchungstext','q.internebemerkung','q.saldo');
-                $searchsql = array('q.kurzbezeichnung', 'q.buchung', 'q.soll', 'q.buchungstext','q.internebemerkung');
+                $findcols = array('q.id','q.id', 'q.importdatum', 'q.kurzbezeichnung', 'q.buchungdatum', 'q.soll', 'q.waehrung', 'q.buchungstext','q.internebemerkung','q.saldo');
+                $searchsql = array('q.kurzbezeichnung', 'q.buchungdatum', 'q.soll', 'q.buchungstext','q.internebemerkung');
 
                 $defaultorder = 1;
                 $defaultorderdesc = 0;
@@ -173,13 +173,14 @@ class Kontoauszuege {
                                     ".$app->erp->FormatMenge('(k.soll)',2).",
                                     '</del>'
                                 ),
-                                ".$app->erp->FormatMenge('(k.soll)',2)."),
+                                ".$app->erp->FormatMenge('(k.soll)',2).") AS soll,
                             k.waehrung,
                             k.buchungstext,
                             k.internebemerkung,
                             ".$app->erp->FormatMenge('SUM(fb.betrag)',2)." AS saldo,
                             k.id as menuid,
-                            SUM(fb.betrag) AS saldonum
+                            SUM(fb.betrag) AS saldonum,
+                            k.buchung AS buchungdatum
                         FROM kontoauszuege k
                         LEFT JOIN fibu_buchungen_alle fb ON
                             fb.id = k.id AND fb.typ = 'kontoauszuege'


### PR DESCRIPTION
With this fix sorting and searching the date columns for kontoauszuege and buchungen now works.

If a column contains 'datum' in its name or is of type date, sorting/searching for both YYYY-MM-DD or DD.MM.YYYY will work.