### PR TITLE
always use currency from auftrag for auftrag_positionen

### DIFF
--- a/classes/Components/MailClient/Data/MailAttachmentData.php
+++ b/classes/Components/MailClient/Data/MailAttachmentData.php
@@ -74,6 +74,11 @@ class MailAttachmentData implements MailAttachmentInterface
                 if ($content_type == 'application/octet-stream') {
                     return('application/octet-stream');
                 }                
+                // Check for application/pdf
+                $content_type = $part->getContentType();
+                if ($content_type == 'application/pdf') {
+                    return('application/pdf');
+                }
                 // Check for Content-id
                 $contentIdHeader = $part->getHeader('content-id');                                              
                 if ($contentIdHeader !== null) {

--- a/classes/Modules/Ticket/Task/TicketImportHelper.php
+++ b/classes/Modules/Ticket/Task/TicketImportHelper.php
@@ -558,13 +558,7 @@ class TicketImportHelper
         }        
 
         if ($plainTextBody == '' && $htmlBody == '') {
-            $simple_content = $message->getContent();
-            if (empty($simple_content)) {
-                $this->logger->debug('Empty mail',[]);    
-            } else {
-                $plainTextBody = $simple_content;
-                $htmlBody = nl2br(htmlentities($simple_content));
-            }
+            $this->logger->debug('Empty mail',[]);
         }
 
         $this->logger->debug('Text',['plain' => $plainTextBody, 'html' => $htmlBody, 'simple_content' => $simple_content]);            

--- a/www/pages/ajax.php
+++ b/www/pages/ajax.php
@@ -3069,12 +3069,6 @@ select a.kundennummer, (SELECT name FROM adresse a2 WHERE a2.kundennummer = a.ku
 
         $adresse = $document['adresse'];// $this->app->DB->Select("SELECT adresse FROM $smodule WHERE id='$sid' LIMIT 1");
         $waehrung = $document['waehrung'];//$this->app->DB->Select("SELECT waehrung FROM $smodule WHERE id='$sid' LIMIT 1");
-        $posanz = (int)$this->app->DB->Select("SELECT count(id) FROM $smodule"."_position WHERE $smodule = '$sid'");
-        
-        if($posanz == 0)
-        {
-          $waehrung = '';
-        }
         
         $anzeigebrutto = false;
         if($smodule == 'auftrag' || $smodule == 'rechnung' || $smodule == 'gutschrift' || $smodule == 'angebot' || $smodule == 'proformarechnung')

--- a/www/pages/artikel.php
+++ b/www/pages/artikel.php
@@ -3699,8 +3699,8 @@ class Artikel extends GenArtikel {
 	      $adresse = $this->app->DB->Select("SELECT adresse FROM $smodule WHERE id='$sid' LIMIT 1");
 	}
 
-	if (!is_null($module)) {
-		if ($this->app->DB->Select("SHOW COLUMNS FROM `$module` LIKE 'waehrung'")) {
+	if (!is_null($smodule)) {
+		if ($this->app->DB->Select("SHOW COLUMNS FROM `$smodule` LIKE 'waehrung'")) {
 		      $waehrung = $this->app->DB->Select("SELECT waehrung FROM $smodule WHERE id='$sid' LIMIT 1");
 		}
 	}

--- a/www/pages/content/etiketten_bild.tpl
+++ b/www/pages/content/etiketten_bild.tpl
@@ -7,9 +7,10 @@
 
 <!-- erstes tab -->
 <div id="tabs-1">
+[MESSAGE]
 <form action="" method="post" enctype="multipart/form-data">
 <fieldset><legend>{|Bild heraufladen|}</legend>
-<i>Hinweis: Es werden aktuell nur Monochrom PNG Dateien unterst&uuml;tzt. Die Bildbreite muss durch 8 teilbar sein! z.B. 520 Pixel oder 640 Pixel. 800 Pixel entsprechen 10 cm.</i>
+<i>Hinweis: Es werden aktuell nur JPG-Dateien unterst&uuml;tzt.</i>
 <table>
 <tr><td>Datei:</td><td><input type="file" name="image"></td><td><input type="submit" name="submit" value="Hochladen"></td>
 </tr></table>

--- a/www/pages/etiketten.php
+++ b/www/pages/etiketten.php
@@ -96,14 +96,16 @@ class Etiketten extends GenEtiketten {
     { 
       if(file_exists($pfad))
       {
-        $result = $this->app->erp->PNG2Etikett($pfad);
-        if($result['result']=="1")
-        {
-          $this->app->Tpl->Set('BILD',"<textarea rows=\"10\" cols=\"80\"><image x=\"1\" y=\"1\" width=\"".$result['width']."\" height=\"".$result['height']."\">".$result['stream']."</image></textarea>");
-          $this->app->Tpl->Set('BILD2',"<textarea rows=\"10\" cols=\"80\"><label><image x=\"1\" y=\"1\" width=\"".$result['width']."\" height=\"".$result['height']."\">".$result['stream']."</image></label></textarea>");
+        $result = getimagesize($pfad);
+        $stream = base64_encode(file_get_contents($pfad));
+        if($result !== false)
+        {           
+          $this->app->Tpl->Set('BILD',"<textarea rows=\"10\" cols=\"80\">\n<image x=\"1\" y=\"1\" width=\"".$result[0]."\" height=\"".$result[1]."\">\n".$stream."\n</image>\n</textarea>");
+          $this->app->Tpl->Set('BILD2',"<textarea rows=\"10\" cols=\"80\">\n<label>\n<image x=\"1\" y=\"1\" width=\"".$result[0]."\" height=\"".$result[1]."\">".$stream."</image>\n</label>\n</textarea>");
         } 
-        else
-          $this->app->Tpl->Set('BILD',"<div class=\"error\">".$result['message']."</div>");
+        else {
+          $this->app->Tpl->Set('MESSAGE',"<div class=\"error\">Datei konnte nicht geladen werden</div>");
+        }
       }
     } 
 

--- a/www/widgets/templates/_gen/projekt.tpl
+++ b/www/widgets/templates/_gen/projekt.tpl
@@ -122,7 +122,12 @@
               </tr>
               <tr>
                 <td>{|Auto-Versand als Standard deaktivieren|}:</td>
-                <td>[DEACTIVATEAUTOSHIPPING][MSGDEACTIVATEAUTOSHIPPING]</td>
+                <td>[DEACTIVATEAUTOSHIPPING][MSGDEACTIVATEAUTOSHIPPING]</td>    
+              </tr>
+              <tr>
+                <td>
+                    Standard Versandart:</td><td>[VERSANDART][MSGVERSANDART]
+                </td>
               </tr>
               <tr><td>{|Drucker Stufe (Kommissionierung)|}</td><td>[DRUCKERLOGISTIKSTUFE1][MSGDRUCKERLOGISTIKSTUFE1]&nbsp;<i>{|z.B. Lieferschein drucken|}</i></td></tr>
   	          <tr><td>{|Drucker Stufe (Versand)|}</td><td>[DRUCKERLOGISTIKSTUFE2][MSGDRUCKERLOGISTIKSTUFE2]&nbsp;<i>{|Belege bei Versandstation|}</i></td></tr>
@@ -338,7 +343,6 @@
              </tr>
              <tr><td>Standard Zahlungsweise Kunde:</td><td>[ZAHLUNGSWEISE][MSGZAHLUNGSWEISE]</td></tr>
              <tr><td>Standard Zahlungsweise Lieferant:</td><td>[ZAHLUNGSWEISELIEFERANT][MSGZAHLUNGSWEISELIEFERANT]</td></tr>
-             <tr><td>Standard Versandart:</td><td>[VERSANDART][MSGVERSANDART]</td></tr>
              <tr><td>{|W&auml;hrung|}:</td><td>[WAEHRUNG][MSGWAEHRUNG]&nbsp;</td></tr>
              <tr><td width="300">{|USt.-ID|}:</td><td>[STEUERNUMMER][MSGSTEUERNUMMER]&nbsp;</td></tr>
              <tr><td>{|Mahnwesen aktiv|}:</td><td>[MAHNWESEN][MSGMAHNWESEN]</td></tr>

--- a/www/widgets/widget.auftrag.php
+++ b/www/widgets/widget.auftrag.php
@@ -54,9 +54,9 @@ class WidgetAuftrag extends WidgetGenAuftrag
             $this->form->HTMLList['standardlager']->dbvalue = $standardlager;
           }
           $deactivateautoshipping = $this->app->erp->Projektdaten($projektdanach, 'deactivateautoshipping');
-          if($deactivateautoshipping && $this->form->CallbackAndMandatorycheck(true)) {
-            $this->form->HTMLList['autoversand']->htmlvalue = 0;
-            $this->form->HTMLList['autoversand']->dbvalue = 0;
+          if($this->form->CallbackAndMandatorycheck(true)) {
+            $this->form->HTMLList['autoversand']->htmlvalue = ($deactivateautoshipping == 0);
+            $this->form->HTMLList['autoversand']->dbvalue = ($deactivateautoshipping == 0);
           }
           $query = sprintf("SELECT zahlungsweise, zahlungsweiselieferant, versandart FROM projekt WHERE id='%s'",
             $projektdanach);
@@ -219,7 +219,7 @@ class WidgetAuftrag extends WidgetGenAuftrag
     //    $field->onchange="versand(this.form.versandart.options[this.form.versandart.selectedIndex].value);";
     $field->AddOptionsSimpleArray($versandart);
     $this->form->NewField($field);
-    if(!empty($overwriteZahlungsweise)){
+    if(!empty($overwriteVersandart)){
       $this->form->HTMLList['versandart']->htmlvalue = $overwriteVersandart;
       $this->form->HTMLList['versandart']->dbvalue = $overwriteVersandart;
     }


### PR DESCRIPTION
When having articles with prices with several currencies (e.g. EUR and USD), auftrag_positionen should use the currency set in auftrag (from adresse).

There was also a bug that in artikel.php the wrong $module variable was used for currency query (leading to $waehrung == null and thus currency of GetVerkaufspreisWaehrung() was used - which was somehow different than desired currency of auftrag).