### PR TITLE
make smtp auth not manadatory

### DIFF
--- a/classes/Components/Mailer/Transport/PhpMailerTransport.php
+++ b/classes/Components/Mailer/Transport/PhpMailerTransport.php
@@ -32,6 +32,13 @@ final class PhpMailerTransport implements MailerTransportInterface
     {
         $this->config = $config;
         $this->phpMailer = $mailer;
+        //no username, no password = no SMTPAuth
+        if($config->getConfigValue('username', '') == '' && $config->getConfigValue('pasword', '') == '') {
+            $this->phpMailer->SMTPAuth = false;
+        } else {
+            $this->phpMailer->SMTPAuth = $config->getConfigValue('smtp_enabled', false);    
+        }
+
         $this->phpMailer->Priority = $config->getConfigValue('priority', 3);
         $this->phpMailer->CharSet = $config->getConfigValue('charset', 'iso-8859-1');
         $this->phpMailer->ContentType = $config->getConfigValue('contenttype', 'text/plain');
@@ -45,12 +52,9 @@ final class PhpMailerTransport implements MailerTransportInterface
         $this->phpMailer->Port = $config->getConfigValue('port', 25);
         $this->phpMailer->Helo = $config->getConfigValue('helo', '');
         $this->phpMailer->SMTPSecure = $config->getConfigValue('smtp_security', '');
-        $this->phpMailer->SMTPAuth = $config->getConfigValue('smtp_enabled', false);
         $this->phpMailer->AuthType = $config->getConfigValue('auth_type', 'smtp');
         $this->phpMailer->SMTPAutoTLS = $config->getConfigValue('smtp_autotls_enabled', false);
         $this->phpMailer->SMTPOptions = $config->getConfigValue('smtp_options', []);
-        $this->phpMailer->Username = $config->getConfigValue('username', '');
-        $this->phpMailer->Password = $config->getConfigValue('password', '');
         $this->phpMailer->Timeout = $config->getConfigValue('timeout', 30);
         $this->phpMailer->SMTPDebug = $config->getConfigValue('smtp_debug', 0);
         $this->phpMailer->SMTPKeepAlive = $config->getConfigValue('smtp_keepalive', false);


### PR DESCRIPTION
- if no username and password set, smtpauth is disabled in PhpMailerTransport
- fixex #194 