### PR TITLE
Option 'Beschreibung aus Auftragsposition übernehmen' hinzufügen

### DIFF
--- a/www/lib/class.erpapi.php
+++ b/www/lib/class.erpapi.php
@@ -33185,13 +33185,13 @@ function Firmendaten($field,$projekt="")
         }
       }
 
-      function AddBestellungPosition($bestellung, $einkauf,$menge,$datum, $beschreibung = '',$artikel="",$einheit="", $waehrung = '')
+      function AddBestellungPosition($bestellung, $einkauf,$menge,$datum, $beschreibung = '',$artikel="",$einheit="", $waehrung = '', $auftrag_position_id = 0)
       {
         /** @var Bestellung $obj */
         $obj = $this->LoadModul('bestellung');
         if(!empty($obj) && method_exists($obj, 'AddBestellungPosition'))
         {
-          return $obj->AddBestellungPosition($bestellung, $einkauf,$menge,$datum, $beschreibung,$artikel,$einheit, $waehrung);
+          return $obj->AddBestellungPosition($bestellung, $einkauf,$menge,$datum, $beschreibung,$artikel,$einheit, $waehrung, $auftrag_position_id);
         }
       }
 

--- a/www/pages/bestellvorschlag.php
+++ b/www/pages/bestellvorschlag.php
@@ -596,6 +596,18 @@ FROM
                             }
                         }
                         $this->app->erp->BestellungNeuberechnen($bestellid);
+
+                        $ids_zum_loeschen = array();
+                        foreach ($bestelladresse['positionen'] as $pos) {
+                            $aid = (int)$pos['id'];
+                            if($aid > 0) {
+                                $ids_zum_loeschen[] = $aid;
+                            }
+                        }
+                        if(!empty($ids_zum_loeschen)) {
+                            $ids_sql = implode(',', $ids_zum_loeschen);
+                            $this->app->DB->Delete("DELETE FROM bestellvorschlag WHERE user = $user AND artikel IN ($ids_sql)");
+                        }
                     }
                 }
                 $msg .= "<div class=\"success\">Es wurden $angelegt Bestellungen angelegt.</div>";

--- a/www/pages/bestellvorschlag.php
+++ b/www/pages/bestellvorschlag.php
@@ -369,7 +369,7 @@ FROM
                         INNER JOIN bestellung b ON b.id = bp.bestellung
                         WHERE bp.artikel = aufp.artikel
                         AND b.status IN ('angelegt','freigegeben','versendet')
-                        AND bp.beschreibung LIKE CONCAT('%[AP#', aufp.id, ']%')
+                        AND bp.auftrag_position_id = aufp.id
                     ), 0),
                     0
                 ) AS restmenge,
@@ -558,22 +558,18 @@ FROM
                                     }
 
                                     $beschreibung = trim((string)$bedarf['beschreibung']);
-                                    $apTag = ' [AP#' . (int)$bedarf['auftrag_position_id'] . ']';
-                                    if ($beschreibung === '') {
-                                        $beschreibungMitTag = $apTag;
-                                    } else {
-                                        $beschreibungMitTag = (strpos($beschreibung, $apTag) === false) 
-                                            ? $beschreibung . $apTag 
-                                            : $beschreibung; // falls schon vorhanden
-                                    }
+                                    $auftragpositionid = $bedarf['auftrag_position_id'];
 
                                     $this->app->erp->AddBestellungPosition(
                                         $bestellid,
                                         $preisid,
                                         $teilmenge,
                                         $datum,
-                                        $beschreibungMitTag,
-                                        $artikelohnepreis
+                                        $beschreibung,
+                                        $artikelohnepreis,
+                                        '',
+                                        '',
+                                        $auftragpositionid
                                     );
 
                                     $rest -= $teilmenge;

--- a/www/pages/content/bestellvorschlag_list.tpl
+++ b/www/pages/content/bestellvorschlag_list.tpl
@@ -12,12 +12,22 @@
                            <fieldset>
                                 <table width="100%" border="0" class="mkTableFormular">
                                     <legend>{|Einstellungen|}</legend>
+                                    <tr>
                                         <td>{|Absatz ber&uuml;cksichtigen (Monate)|}:</td>
                                         <td><input type="number" min="0" name="monate_absatz" id="monate_absatz" value="[MONATE_ABSATZ]" size="20"></td>
                                     </tr>
                                     <tr>
                                         <td>{|Vorausplanen (Monate)|}:</td>
                                         <td><input type="number" min="0" name="monate_voraus" id="monate_voraus" value="[MONATE_VORAUS]" size="20"></td>
+                                    </tr>
+                                    <tr>
+                                        <td>{|Beschreibung aus Auftragsposition &uuml;bernehmen|}:</td>
+                                        <td>
+                                            <label for="beschreibung_aus_auftrag" class="switch">
+                                                <input type="checkbox" name="beschreibung_aus_auftrag" id="beschreibung_aus_auftrag" value="1" [BESCHREIBUNG_AUS_AUFTRAG]>
+                                                <span class="slider round"></span>
+                                            </label>
+                                        </td>
                                     </tr>
                                 </table>
                             </fieldset>


### PR DESCRIPTION
Im Modul Bestellvorschlag wurde eine zusätzliche Option eingeführt, mit der Beschreibungen aus offenen Auftragspositionen in Bestellungen übernommen werden können.

* Neue Einstellung *„Beschreibung aus Auftragsposition übernehmen“* in `bestellvorschlag_list.tpl`.
* Speicherung der Benutzereinstellung in den User-Parametern.
* Beim Erzeugen von Bestellungen werden die Positionen aus Aufträgen übernommen, inklusive ihrer individuellen Beschreibungstexte.
* Artikel mit abweichenden Beschreibungen werden nicht zusammengefasst, sondern als separate Bestellpositionen angelegt.
* Ist die Option deaktiviert, bleibt das bisherige Verhalten unverändert (Beschreibungen aus Artikelstammdaten).

**Nutzen:**
Die Funktion ermöglicht eine genauere Abbildung von kundenindividuellen Anforderungen und reduziert den manuellen Aufwand bei Bestellungen, die auf speziellen Auftragspositionen basieren.