### PR TITLE
Feature/searchbar layout clean

### DIFF
--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -7,8 +7,10 @@
 	z-index: 994;
 	top: 55px;
 	left: 18px;
-    width: 250px;
-    height: 440px;
+    width: calc(100vw - 60px);
+    max-width: 1300px;
+    min-width: 700px;
+    height: 100%;
 	background-color: var(--body-background);
 	box-shadow: 3px 3px 10px rgba(0, 0, 0, .33);
 	-webkit-user-select: none;
@@ -18,7 +20,7 @@
 }
 
 #supersearch-overlay.has-detail {
-    width: 890px;
+    width: calc(100vw - 60px);
 }
 
 #supersearch-overlay #supersearch-icon-close {
@@ -37,23 +39,38 @@
 }
 
 #supersearch-overlay .result-wrapper {
-    overflow: auto;
-    width: 250px;
-    height: 416px;
+    overflow-y: auto;
+    width: 100%;
+    height: calc(100% - 36px);
     background-color: var(--body-background);
+    padding: 8px 8px 36px;
+    box-sizing: border-box;
+}
+#supersearch-overlay .result-columns {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+    gap: 12px;
+}
+#supersearch-overlay .result-column {
+    flex: 1 1 0;
+    min-width: 220px;
 }
 #supersearch-overlay .detail-wrapper {
     display: none;
     position: absolute;
     top: 0;
-    left: 250px;
-    width: 640px;
-    height: 440px;
+    left: 40%;
+    width: 60%;
+    height: 520px;
     overflow-y: auto;
     background-color: var(--fieldset);
 }
 #supersearch-overlay.has-detail .detail-wrapper {
     display: block;
+}
+#supersearch-overlay.has-detail .result-wrapper {
+    width: 40%;
 }
 
 #supersearch-overlay .search {
@@ -85,11 +102,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    width: 250px;
+    width: auto;
     padding: 6px 12px;
     font-size: 10px;
     color: var(--text-color);
     background-color: var(--fieldset-dark);
+    box-sizing: border-box;
 }
 
 #supersearch-overlay .detail {

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -9,8 +9,9 @@
 	left: 18px;
     width: calc(100vw - 60px);
     max-width: 1300px;
-    min-width: 700px;
-    height: 100%;
+    min-width: 960px;
+    height: auto;
+    max-height: calc(100vh - 80px);
 	background-color: var(--body-background);
 	box-shadow: 3px 3px 10px rgba(0, 0, 0, .33);
 	-webkit-user-select: none;
@@ -41,7 +42,8 @@
 #supersearch-overlay .result-wrapper {
     overflow-y: auto;
     width: 100%;
-    height: calc(100% - 36px);
+    height: auto;
+    max-height: calc(100vh - 140px);
     background-color: var(--body-background);
     padding: 8px 8px 36px;
     box-sizing: border-box;
@@ -62,7 +64,7 @@
     top: 0;
     left: 40%;
     width: 60%;
-    height: 520px;
+    height: 100%;
     overflow-y: auto;
     background-color: var(--fieldset);
 }

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -8,7 +8,7 @@
 	top: 55px;
 	left: 18px;
     width: calc(100vw - 60px);
-    max-width: 1300px;
+    max-width: none;
     min-width: 960px;
     height: auto;
     max-height: calc(100vh - 80px);
@@ -49,14 +49,14 @@
     box-sizing: border-box;
 }
 #supersearch-overlay .result-columns {
-    display: flex;
-    align-items: flex-start;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
     width: 100%;
     gap: 16px;
 }
 #supersearch-overlay .result-column {
-    flex: 1 1 33%;
-    min-width: 280px;
+    min-width: 0;
 }
 #supersearch-overlay .detail-wrapper {
     display: none;

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -52,11 +52,11 @@
     display: flex;
     align-items: flex-start;
     width: 100%;
-    gap: 12px;
+    gap: 16px;
 }
 #supersearch-overlay .result-column {
-    flex: 1 1 0;
-    min-width: 220px;
+    flex: 1 1 33%;
+    min-width: 280px;
 }
 #supersearch-overlay .detail-wrapper {
     display: none;

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -50,7 +50,7 @@
 }
 #supersearch-overlay .result-columns {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(3, minmax(280px, 1fr));
     align-items: start;
     width: 100%;
     gap: 16px;

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -41,7 +41,7 @@
 
 #supersearch-overlay .result-wrapper {
     overflow-y: auto;
-    width: 100%;
+    width: 65%;
     height: auto;
     max-height: calc(100vh - 140px);
     background-color: var(--body-background);
@@ -62,8 +62,8 @@
     display: none;
     position: absolute;
     top: 0;
-    left: 40%;
-    width: 60%;
+    left: 65%;
+    width: 35%;
     height: 100%;
     overflow-y: auto;
     background-color: var(--fieldset);
@@ -72,7 +72,7 @@
     display: block;
 }
 #supersearch-overlay.has-detail .result-wrapper {
-    width: 40%;
+    width: 65%;
 }
 
 #supersearch-overlay .search {

--- a/classes/Widgets/SuperSearch/www/css/supersearch.css
+++ b/classes/Widgets/SuperSearch/www/css/supersearch.css
@@ -18,6 +18,9 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+    display: flex;
+    flex-direction: row;
+    gap: 0;
 }
 
 #supersearch-overlay.has-detail {
@@ -41,7 +44,9 @@
 
 #supersearch-overlay .result-wrapper {
     overflow-y: auto;
-    width: 65%;
+    flex: 0 1 70%;
+    min-width: 900px;
+    max-width: 1300px;
     height: auto;
     max-height: calc(100vh - 140px);
     background-color: var(--body-background);
@@ -60,10 +65,10 @@
 }
 #supersearch-overlay .detail-wrapper {
     display: none;
-    position: absolute;
+    position: relative;
     top: 0;
-    left: 65%;
-    width: 35%;
+    left: 0;
+    flex: 1 1 auto;
     height: 100%;
     overflow-y: auto;
     background-color: var(--fieldset);
@@ -72,7 +77,7 @@
     display: block;
 }
 #supersearch-overlay.has-detail .result-wrapper {
-    width: 65%;
+    flex: 0 1 65%;
 }
 
 #supersearch-overlay .search {

--- a/classes/Widgets/SuperSearch/www/js/supersearch.js
+++ b/classes/Widgets/SuperSearch/www/js/supersearch.js
@@ -314,7 +314,7 @@ var SuperSearch = (function ($) {
             var prioritizedColumns = [
                 {slot: 'left', keys: ['offer', 'order']},
                 {slot: 'middle', keys: ['deliverynote', 'invoice']},
-                {slot: 'right', keys: ['app']}
+                {slot: 'right', keys: ['app', 'apps']}
             ];
 
             var columns = {left: [], middle: [], right: []};
@@ -340,7 +340,7 @@ var SuperSearch = (function ($) {
             });
 
             remaining.forEach(function (groupResult) {
-                if (groupResult.key === 'app') {
+                if (groupResult.key === 'app' || groupResult.key === 'apps') {
                     columns.right.push(groupResult);
                     return;
                 }

--- a/classes/Widgets/SuperSearch/www/js/supersearch.js
+++ b/classes/Widgets/SuperSearch/www/js/supersearch.js
@@ -340,10 +340,12 @@ var SuperSearch = (function ($) {
             });
 
             remaining.forEach(function (groupResult) {
-                var sortedSlots = Object.keys(columns).sort(function (a, b) {
-                    return columns[a].length - columns[b].length;
-                });
-                columns[sortedSlots[0]].push(groupResult);
+                if (groupResult.key === 'app') {
+                    columns.right.push(groupResult);
+                    return;
+                }
+                var targetSlot = columns.left.length <= columns.middle.length ? 'left' : 'middle';
+                columns[targetSlot].push(groupResult);
             });
 
             return ['left', 'middle', 'right']

--- a/classes/Widgets/SuperSearch/www/js/supersearch.js
+++ b/classes/Widgets/SuperSearch/www/js/supersearch.js
@@ -242,11 +242,23 @@ var SuperSearch = (function ($) {
             }
 
             me.storage.$details.html('');
-            Object.keys(searchResults).forEach(function (group) {
-                var groupResult = searchResults[group];
-                var $groupHtml = me.buildGroupResult(groupResult.key, groupResult.title, groupResult.items);
-                $resultContainer.append($groupHtml);
+            var columns = me.buildResultColumns(searchResults);
+            var $columnsWrapper = $('<div class="result-columns">');
+
+            columns.forEach(function (column) {
+                var $column = $('<div class="result-column">');
+                column.forEach(function (groupResult) {
+                    var $groupHtml = me.buildGroupResult(groupResult.key, groupResult.title, groupResult.items);
+                    if (typeof $groupHtml !== 'undefined') {
+                        $column.append($groupHtml);
+                    }
+                });
+                if ($column.children().length > 0) {
+                    $columnsWrapper.append($column);
+                }
             });
+
+            $resultContainer.append($columnsWrapper);
 
             me.storage.hasResults = true;
             me.showResults();
@@ -290,6 +302,57 @@ var SuperSearch = (function ($) {
             $resultWrapper.append($resultList);
 
             return $resultWrapper;
+        },
+
+        /**
+         * Ordnet Suchergebnis-Gruppen dynamisch in Spalten an.
+         *
+         * @param {object} searchResults
+         * @returns {Array}
+         */
+        buildResultColumns: function (searchResults) {
+            var prioritizedColumns = [
+                {slot: 'left', keys: ['offer', 'order']},
+                {slot: 'middle', keys: ['deliverynote', 'invoice']},
+                {slot: 'right', keys: ['app']}
+            ];
+
+            var columns = {left: [], middle: [], right: []};
+            var remaining = [];
+
+            Object.keys(searchResults).forEach(function (group) {
+                var groupResult = searchResults[group];
+                var assigned = false;
+
+                prioritizedColumns.forEach(function (config) {
+                    if (assigned) {
+                        return;
+                    }
+                    if (config.keys.indexOf(groupResult.key) !== -1) {
+                        columns[config.slot].push(groupResult);
+                        assigned = true;
+                    }
+                });
+
+                if (!assigned) {
+                    remaining.push(groupResult);
+                }
+            });
+
+            remaining.forEach(function (groupResult) {
+                var sortedSlots = Object.keys(columns).sort(function (a, b) {
+                    return columns[a].length - columns[b].length;
+                });
+                columns[sortedSlots[0]].push(groupResult);
+            });
+
+            return ['left', 'middle', 'right']
+                .map(function (slot) {
+                    return columns[slot];
+                })
+                .filter(function (column) {
+                    return column.length > 0;
+                });
         },
 
         /**


### PR DESCRIPTION
- **Ziel**: SuperSearch-Overlay breiter und strukturierter darstellen.
- **Umgesetzt**: Drei Spalten über die gesamte verfügbare Breite; dynamische Breitenanpassung an den Viewport; Apps immer in der rechten Spalte, Angebote/Aufträge links, Lieferscheine/Rechnungen mittig. Meta-Leiste unten breiter.
- **Erwartetes Verhalten**: Suchergebnisse füllen den Platz auf breiten Bildschirmen; Apps tauchen nicht mehr vor Aufträgen/Rechnungen auf; bei Detailanzeige bleibt die Spaltenaufteilung stabil.