### PR TITLE
Feature/detail angebote auftraege clean

### DIFF
--- a/www/widgets/templates/_gen/angebot.tpl
+++ b/www/widgets/templates/_gen/angebot.tpl
@@ -83,7 +83,39 @@
     <div class="col-xs-12 col-sm-6 col-sm-height">
       <div class="inside inside-full-height">
 
-      <fieldset><legend>{|Allgemein|}</legend>
+      <fieldset><legend>{|Stammdaten|}</legend>
+      <table border="0" class="mkTableFormular">
+              <tr><td width="200">{|Typ|}:</td><td width="200">[TYP][MSGTYP]</td></tr>
+              <tr><td>{|Name|}:</td><td>[NAME][MSGNAME]</td></tr>
+              <tr><td>{|Titel|}:</td><td>[TITEL][MSGTITEL]</td></tr>
+              <tr><td>{|Ansprechpartner|}:</td><td>[ANSPRECHPARTNER][MSGANSPRECHPARTNER]</td></tr>
+              <tr><td>{|Abteilung|}:</td><td>[ABTEILUNG][MSGABTEILUNG]</td></tr>
+              <tr><td>{|Unterabteilung|}:</td><td>[UNTERABTEILUNG][MSGUNTERABTEILUNG]</td></tr>
+              <tr><td>{|Adresszusatz|}:</td><td>[ADRESSZUSATZ][MSGADRESSZUSATZ]</td></tr>
+              <tr><td>{|Stra&szlig;e|}:</td><td>[STRASSE][MSGSTRASSE]</td></tr>
+              <tr><td>{|PLZ/Ort|}:</td><td>[PLZ][MSGPLZ]&nbsp;[ORT][MSGORT]</td></tr>
+              [VORBUNDESSTAAT]<tr valign="top"><td><label for="bundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_BUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
+              <tr><td>{|Land|}:</td><td>[EPROO_SELECT_LAND]</td></tr>
+    </table>
+
+      <table class="mkTableFormular">
+                <tr><td>{|Telefon|}:</td><td>[TELEFON][MSGTELEFON]</td></tr>
+                <tr><td>{|Telefax|}:</td><td>[TELEFAX][MSGTELEFAX]</td></tr>
+              <tr><td>{|E-Mail|}:</td><td>[EMAIL][MSGEMAIL]</td></tr>
+               <tr><td>{|Anschreiben|}:</td><td>[ANSCHREIBEN][MSGANSCHREIBEN]</td></tr>
+                <tr><td></td><td>[ANSPRECHPARTNERPOPUP]&nbsp;</td></tr>
+    </table>
+
+
+    </fieldset>
+
+      </div>
+    </div>
+
+    <div class="col-xs-12 col-sm-6 col-sm-height">
+      <div class="inside inside-full-height">
+
+        <fieldset><legend>{|Allgemein|}</legend>
       <table class="mkTableFormular">
         <tr><td>{|Kunde|}:</td><td>[ADRESSE][MSGADRESSE]
       [BUTTON_UEBERNEHMEN]
@@ -103,38 +135,6 @@
       </table>
 
       </fieldset>
-
-      </div>
-    </div>
-
-    <div class="col-xs-12 col-sm-6 col-sm-height">
-      <div class="inside inside-full-height">
-
-        <fieldset><legend>{|Stammdaten|}</legend>
-          <table border="0" class="mkTableFormular">
-                  <tr><td width="200">{|Typ|}:</td><td width="200">[TYP][MSGTYP]</td></tr>
-                  <tr><td>{|Name|}:</td><td>[NAME][MSGNAME]</td></tr>
-                  <tr><td>{|Titel|}:</td><td>[TITEL][MSGTITEL]</td></tr>
-                  <tr><td>{|Ansprechpartner|}:</td><td>[ANSPRECHPARTNER][MSGANSPRECHPARTNER]</td></tr>
-                  <tr><td>{|Abteilung|}:</td><td>[ABTEILUNG][MSGABTEILUNG]</td></tr>
-                  <tr><td>{|Unterabteilung|}:</td><td>[UNTERABTEILUNG][MSGUNTERABTEILUNG]</td></tr>
-                  <tr><td>{|Adresszusatz|}:</td><td>[ADRESSZUSATZ][MSGADRESSZUSATZ]</td></tr>
-                  <tr><td>{|Stra&szlig;e|}:</td><td>[STRASSE][MSGSTRASSE]</td></tr>
-                  <tr><td>{|PLZ/Ort|}:</td><td>[PLZ][MSGPLZ]&nbsp;[ORT][MSGORT]</td></tr>
-                  [VORBUNDESSTAAT]<tr valign="top"><td><label for="bundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_BUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
-                  <tr><td>{|Land|}:</td><td>[EPROO_SELECT_LAND]</td></tr>
-        </table>
-
-          <table class="mkTableFormular">
-                    <tr><td>{|Telefon|}:</td><td>[TELEFON][MSGTELEFON]</td></tr>
-                    <tr><td>{|Telefax|}:</td><td>[TELEFAX][MSGTELEFAX]</td></tr>
-                  <tr><td>{|E-Mail|}:</td><td>[EMAIL][MSGEMAIL]</td></tr>
-                   <tr><td>{|Anschreiben|}:</td><td>[ANSCHREIBEN][MSGANSCHREIBEN]</td></tr>
-                    <tr><td></td><td>[ANSPRECHPARTNERPOPUP]&nbsp;</td></tr>
-        </table>
-
-
-        </fieldset>
 
 
       </div>

--- a/www/widgets/templates/_gen/angebot.tpl
+++ b/www/widgets/templates/_gen/angebot.tpl
@@ -108,41 +108,6 @@
     </div>
 
     <div class="col-xs-12 col-sm-6 col-sm-height">
-      <div class="inside_turkey inside-full-height">
-
-        <div id="abweichendelieferadressestyle">
-        <fieldset class="turkey"><legend>{|Abweichende Lieferadresse|}</legend>
-          <table class="tableabweichend">
-            <tr><td width="200">{|Abweichende Lieferadresse|}:</td><td>[ABWEICHENDELIEFERADRESSE][MSGABWEICHENDELIEFERADRESSE]</td></tr>
-            <tr><td>{|Name|}:</td><td>[LIEFERNAME][MSGLIEFERNAME]</td></tr>
-            <tr><td>{|Titel|}:</td><td>[LIEFERTITEL][MSGLIEFERTITEL]</td></tr>
-            <tr><td>{|Ansprechpartner|}:</td><td>[LIEFERANSPRECHPARTNER][MSGLIEFERANSPRECHPARTNER]</td></tr>
-            <tr><td>{|Abteilung|}:</td><td>[LIEFERABTEILUNG][MSGLIEFERABTEILUNG]</td></tr>
-            <tr><td>{|Unterabteilung|}:</td><td>[LIEFERUNTERABTEILUNG][MSGLIEFERUNTERABTEILUNG]</td></tr>
-            <tr><td>{|Adresszusatz|}:</td><td>[LIEFERADRESSZUSATZ][MSGLIEFERADRESSZUSATZ]</td></tr>
-            <tr><td>{|Stra&szlig;e|}:</td><td>[LIEFERSTRASSE][MSGLIEFERSTRASSE]</td><td>&nbsp;</td></tr>
-            <tr><td>{|PLZ/Ort|}:</td><td>[LIEFERPLZ][MSGLIEFERPLZ]&nbsp;[LIEFERORT][MSGLIEFERORT]</td>
-            </tr>
-            [VORBUNDESSTAAT]<tr valign="top"><td><label for="lieferbundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_LIEFERBUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
-            <tr><td>{|Land|}:</td><td>[EPROO_SELECT_LIEFERLAND]</td>
-            <tr><td>{|GLN|}:</td><td>[LIEFERGLN][MSGLIEFERGLN]</td><td>&nbsp;</td></tr>
-            <tr><td>{|E-Mail|}:</td><td>[LIEFEREMAIL][MSGLIEFEREMAIL]</td></tr>
-            <tr><td></td><td>[LIEFERADRESSEPOPUP]&nbsp;[ANSPRECHPARTNERLIEFERADRESSEPOPUP]&nbsp;[ADRESSELIEFERADRESSEPOPUP]</td></tr>
-        </table>
-        </fieldset>
-        </div>
-
-
-      </div>
-    </div>
-  </div>
-</div> <!-- spalte 2 zu -->
-
-
-
-<div class="row">
-  <div class="row-height">
-    <div class="col-xs-12 col-md-9 col-md-height">
       <div class="inside inside-full-height">
 
         <fieldset><legend>{|Stammdaten|}</legend>
@@ -170,6 +135,41 @@
 
 
         </fieldset>
+
+
+      </div>
+    </div>
+  </div>
+</div> <!-- spalte 2 zu -->
+
+
+
+<div class="row">
+  <div class="row-height">
+    <div class="col-xs-12 col-md-9 col-md-height">
+      <div class="inside_turkey inside-full-height">
+
+        <div id="abweichendelieferadressestyle">
+        <fieldset class="turkey"><legend>{|Abweichende Lieferadresse|}</legend>
+          <table class="tableabweichend">
+            <tr><td width="200">{|Abweichende Lieferadresse|}:</td><td>[ABWEICHENDELIEFERADRESSE][MSGABWEICHENDELIEFERADRESSE]</td></tr>
+            <tr><td>{|Name|}:</td><td>[LIEFERNAME][MSGLIEFERNAME]</td></tr>
+            <tr><td>{|Titel|}:</td><td>[LIEFERTITEL][MSGLIEFERTITEL]</td></tr>
+            <tr><td>{|Ansprechpartner|}:</td><td>[LIEFERANSPRECHPARTNER][MSGLIEFERANSPRECHPARTNER]</td></tr>
+            <tr><td>{|Abteilung|}:</td><td>[LIEFERABTEILUNG][MSGLIEFERABTEILUNG]</td></tr>
+            <tr><td>{|Unterabteilung|}:</td><td>[LIEFERUNTERABTEILUNG][MSGLIEFERUNTERABTEILUNG]</td></tr>
+            <tr><td>{|Adresszusatz|}:</td><td>[LIEFERADRESSZUSATZ][MSGLIEFERADRESSZUSATZ]</td></tr>
+            <tr><td>{|Stra&szlig;e|}:</td><td>[LIEFERSTRASSE][MSGLIEFERSTRASSE]</td><td>&nbsp;</td></tr>
+            <tr><td>{|PLZ/Ort|}:</td><td>[LIEFERPLZ][MSGLIEFERPLZ]&nbsp;[LIEFERORT][MSGLIEFERORT]</td>
+            </tr>
+            [VORBUNDESSTAAT]<tr valign="top"><td><label for="lieferbundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_LIEFERBUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
+            <tr><td>{|Land|}:</td><td>[EPROO_SELECT_LIEFERLAND]</td>
+            <tr><td>{|GLN|}:</td><td>[LIEFERGLN][MSGLIEFERGLN]</td><td>&nbsp;</td></tr>
+            <tr><td>{|E-Mail|}:</td><td>[LIEFEREMAIL][MSGLIEFEREMAIL]</td></tr>
+            <tr><td></td><td>[LIEFERADRESSEPOPUP]&nbsp;[ANSPRECHPARTNERLIEFERADRESSEPOPUP]&nbsp;[ADRESSELIEFERADRESSEPOPUP]</td></tr>
+        </table>
+        </fieldset>
+        </div>
 
 
       </div>

--- a/www/widgets/templates/_gen/auftrag.tpl
+++ b/www/widgets/templates/_gen/auftrag.tpl
@@ -81,6 +81,39 @@ function abweichend2()
 <div class="col-xs-12 col-sm-6 col-sm-height">
 <div class="inside inside-full-height">
 
+<fieldset><legend>{|Stammdaten|}</legend>
+
+<table border="0" class="mkTableFormular">
+<tr><td width="200">{|Typ|}:</td><td width="200">[TYP][MSGTYP]</td></tr>
+<tr><td>{|Name|}:</td><td>[NAME][MSGNAME]</td></tr>
+<tr><td>{|Titel|}:</td><td>[TITEL][MSGTITEL]</td></tr>
+<tr><td>{|Ansprechpartner|}:</td><td>[ANSPRECHPARTNER][MSGANSPRECHPARTNER]</td></tr>            <tr><td>{|Abteilung|}:</td><td>[ABTEILUNG][MSGABTEILUNG]</td></tr>
+<tr><td>{|Unterabteilung|}:</td><td>[UNTERABTEILUNG][MSGUNTERABTEILUNG]</td></tr>
+<tr><td>{|Adresszusatz|}:</td><td>[ADRESSZUSATZ][MSGADRESSZUSATZ]</td></tr>
+<tr><td>{|Stra&szlig;e|}:</td><td>[STRASSE][MSGSTRASSE]</td></tr>
+<tr><td>{|PLZ/Ort|}:</td><td>[PLZ][MSGPLZ]&nbsp;[ORT][MSGORT]</td></tr>
+[VORBUNDESSTAAT]<tr valign="top"><td><label for="bundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_BUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
+<tr><td>{|Land|}:</td><td>[EPROO_SELECT_LAND]</td></tr>
+</table>
+
+<table class="mkTableFormular">
+<tr><td>{|Telefon|}:</td><td>[TELEFON][MSGTELEFON]</td></tr>
+<tr><td>{|Telefax|}:</td><td>[TELEFAX][MSGTELEFAX]</td></tr>
+<tr><td>{|E-Mail|}:</td><td>[EMAIL][MSGEMAIL]</td></tr>
+<tr><td>{|Anschreiben|}:</td><td>[ANSCHREIBEN][MSGANSCHREIBEN]</td></tr>
+<tr><td></td><td>[ANSPRECHPARTNERPOPUP]&nbsp;</td></tr>
+</table>    
+
+</fieldset>
+
+
+</div>
+
+</div>
+
+<div class="col-xs-12 col-sm-6 col-sm-height">
+<div class="inside inside-full-height">
+
 <fieldset><legend>{|Allgemein|}</legend>
 <table class="mkTableFormular">
 <tr id="kundestyle"><td>{|Kunde|}</td><td nowrap>[ADRESSE][MSGADRESSE]&nbsp;[BUTTON_UEBERNEHMEN]</td></tr>
@@ -109,10 +142,17 @@ function abweichend2()
 
 
 </div>
-
 </div>
+</div>
+</div> <!-- spalte 2 zu -->
 
-<div class="col-xs-12 col-sm-6 col-sm-height">
+
+
+
+
+<div class="row">
+<div class="row-height">
+<div class="col-xs-12 col-md-9 col-md-height">
 <div class="inside_turkey inside-full-height">
 
 
@@ -138,46 +178,6 @@ function abweichend2()
 </fieldset>
 </div>
 
-
-</div>
-</div>
-</div>
-</div> <!-- spalte 2 zu -->
-
-
-
-
-
-<div class="row">
-<div class="row-height">
-<div class="col-xs-12 col-md-9 col-md-height">
-<div class="inside inside-full-height">
-
-
-<fieldset><legend>{|Stammdaten|}</legend>
-
-<table border="0" class="mkTableFormular">
-<tr><td width="200">{|Typ|}:</td><td width="200">[TYP][MSGTYP]</td></tr>
-<tr><td>{|Name|}:</td><td>[NAME][MSGNAME]</td></tr>
-<tr><td>{|Titel|}:</td><td>[TITEL][MSGTITEL]</td></tr>
-<tr><td>{|Ansprechpartner|}:</td><td>[ANSPRECHPARTNER][MSGANSPRECHPARTNER]</td></tr>            <tr><td>{|Abteilung|}:</td><td>[ABTEILUNG][MSGABTEILUNG]</td></tr>
-<tr><td>{|Unterabteilung|}:</td><td>[UNTERABTEILUNG][MSGUNTERABTEILUNG]</td></tr>
-<tr><td>{|Adresszusatz|}:</td><td>[ADRESSZUSATZ][MSGADRESSZUSATZ]</td></tr>
-<tr><td>{|Stra&szlig;e|}:</td><td>[STRASSE][MSGSTRASSE]</td></tr>
-<tr><td>{|PLZ/Ort|}:</td><td>[PLZ][MSGPLZ]&nbsp;[ORT][MSGORT]</td></tr>
-[VORBUNDESSTAAT]<tr valign="top"><td><label for="bundesstaat">{|Bundesstaat|}:</label></td><td colspan="2">[EPROO_SELECT_BUNDESSTAAT]</td></tr>[NACHBUNDESSTAAT]
-<tr><td>{|Land|}:</td><td>[EPROO_SELECT_LAND]</td></tr>
-</table>
-
-<table class="mkTableFormular">
-<tr><td>{|Telefon|}:</td><td>[TELEFON][MSGTELEFON]</td></tr>
-<tr><td>{|Telefax|}:</td><td>[TELEFAX][MSGTELEFAX]</td></tr>
-<tr><td>{|E-Mail|}:</td><td>[EMAIL][MSGEMAIL]</td></tr>
-<tr><td>{|Anschreiben|}:</td><td>[ANSCHREIBEN][MSGANSCHREIBEN]</td></tr>
-<tr><td></td><td>[ANSPRECHPARTNERPOPUP]</td></tr>
-</table>    
-
-</fieldset>
 
 </div>
 </div>


### PR DESCRIPTION
- **Ziel**: Detailansichten von Angeboten/Aufträgen klarer darstellen.
- **Umgesetzt**: Stammdaten links, Allgemein rechts, darunter abweichende Lieferadresse; Umschalt-Option in den Einstellungen zwischen Standard- und neuer Ansicht.
- **Erwartetes Verhalten**: Auf Full-HD-Bildschirmen sind Auftragsnummer und relevante Daten besser sichtbar; Umschalten der Ansicht möglich.