### PR TITLE
Feature/paid marking clean

### DIFF
--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -1901,17 +1901,25 @@ class Auftrag extends GenAuftrag
   /**
    * Entfernt kurzzeitig den Schreibschutz, markiert den Auftrag als bezahlt und setzt den Schreibschutz erneut.
    */
-  public function AuftragPaidAndLock()
+  public function AuftragPaidAndLock($id = null, bool $redirect = true)
   {
-    $id = (int)$this->app->Secure->GetGET('id');
+    if($id === null){
+      $id = (int)$this->app->Secure->GetGET('id');
+    }
 
     if($id <= 0){
-      $this->app->Location->execute('index.php?module=auftrag&action=list');
+      if($redirect){
+        $this->app->Location->execute('index.php?module=auftrag&action=list');
+      }
+      return;
     }
 
     if(!$this->app->erp->RechteVorhanden('auftrag','edit')) {
       $this->app->erp->RunHook('permission_denied', 4, 'auftrag', 'edit');
-      $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+      if($redirect){
+        $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+      }
+      return;
     }
 
     $this->app->DB->Update(
@@ -1929,7 +1937,9 @@ class Auftrag extends GenAuftrag
     );
     $this->app->erp->AuftragProtokoll($id,'Schreibschutz nach Bezahlmarkierung gesetzt');
 
-    $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+    if($redirect){
+      $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+    }
   }
 
   /**
@@ -7010,6 +7020,11 @@ Die Gesamtsumme stimmt nicht mehr mit urspr&uuml;nglich festgelegten Betrag '.
           case 'versandfreigeben':
             if(!empty($selectedIds)) {
               $this->app->DB->Update('UPDATE auftrag SET autoversand = 1 WHERE id IN ('. implode(', ', $selectedIds) . ')');
+            }
+          break;
+          case 'paidlock':
+            foreach($selectedIds as $v){
+              $this->AuftragPaidAndLock($v,false);
             }
           break;
           case 'versandentfernen':

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -1635,7 +1635,7 @@ class Auftrag extends GenAuftrag
       $teillieferungen
       $auswahlentsprechendkommissionierung
       $zertifikatoption
-      <option value=\"paidlock\">als bezahlt markieren</option>
+      <option value=\"paidlock\">bezahlt markieren (mit Schreibschutz-Reset)</option>
       $artikeleinlagern
       $artikelauslagern
       $shopexport

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -965,6 +965,7 @@ class Auftrag extends GenAuftrag
     $this->app->ActionHandler("proforma","AuftragProforma");
     $this->app->ActionHandler("versand","AuftragVersand");
     $this->app->ActionHandler("zahlungsmail","AuftragZahlungsmail");
+    $this->app->ActionHandler("paidlock","AuftragPaidAndLock");
     $this->app->ActionHandler("reservieren","AuftragReservieren");
     $this->app->ActionHandler("nachlieferung","AuftragNachlieferung");
     $this->app->ActionHandler("protokoll","AuftragProtokoll");
@@ -1597,6 +1598,7 @@ class Auftrag extends GenAuftrag
           case 'freigabe':  window.location.href='index.php?module=auftrag&action=freigabe&id=%value%'; break;
           case 'abschluss': if(!confirm('Wirklich manuell ohne erstellen von Lieferschein und/oder Rechnung als abgeschlossen markieren?')) return document.getElementById('aktion$prefix').selectedIndex = 0; else window.location.href='index.php?module=auftrag&action=abschluss&id=%value%&abschluss=%value%'; break;
           case 'alsfreigegeben': if(!confirm('Wirklich als freigegeben markieren?')) return document.getElementById('aktion$prefix').selectedIndex = 0; else window.location.href='index.php?module=auftrag&action=alsfreigegeben&id=%value%&alsfreigegeben=%value%'; break;
+          case 'paidlock': if(!confirm('Schreibschutz kurz entfernen, Auftrag als bezahlt markieren und wieder sperren?')) return document.getElementById('aktion$prefix').selectedIndex = 0; else window.location.href='index.php?module=auftrag&action=paidlock&id=%value%'; break;
           $menueinlagern
           $menuauslagern
 
@@ -1633,6 +1635,7 @@ class Auftrag extends GenAuftrag
       $teillieferungen
       $auswahlentsprechendkommissionierung
       $zertifikatoption
+      <option value=\"paidlock\">als bezahlt markieren</option>
       $artikeleinlagern
       $artikelauslagern
       $shopexport
@@ -1893,6 +1896,40 @@ class Auftrag extends GenAuftrag
       )
     );
     return ['status' => 1];
+  }
+
+  /**
+   * Entfernt kurzzeitig den Schreibschutz, markiert den Auftrag als bezahlt und setzt den Schreibschutz erneut.
+   */
+  public function AuftragPaidAndLock()
+  {
+    $id = (int)$this->app->Secure->GetGET('id');
+
+    if($id <= 0){
+      $this->app->Location->execute('index.php?module=auftrag&action=list');
+    }
+
+    if(!$this->app->erp->RechteVorhanden('auftrag','edit')) {
+      $this->app->erp->RunHook('permission_denied', 4, 'auftrag', 'edit');
+      $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+    }
+
+    $this->app->DB->Update(
+      sprintf("UPDATE auftrag SET schreibschutz = 0 WHERE id = %d LIMIT 1", $id)
+    );
+    $this->app->erp->AuftragProtokoll($id,'Schreibschutz fuer Bezahlmarkierung entfernt');
+
+    $this->app->DB->Update(
+      sprintf("UPDATE auftrag SET vorabbezahltmarkieren = 1, saldogeprueft = 1 WHERE id = %d LIMIT 1", $id)
+    );
+    $this->app->erp->AuftragProtokoll($id,'Auftrag manuell als bezahlt markiert');
+
+    $this->app->DB->Update(
+      sprintf("UPDATE auftrag SET schreibschutz = 1 WHERE id = %d LIMIT 1", $id)
+    );
+    $this->app->erp->AuftragProtokoll($id,'Schreibschutz nach Bezahlmarkierung gesetzt');
+
+    $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
   }
 
   /**

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -7023,9 +7023,14 @@ Die Gesamtsumme stimmt nicht mehr mit urspr&uuml;nglich festgelegten Betrag '.
             }
           break;
           case 'paidlock':
+            if(empty($selectedIds)){
+              break;
+            }
             foreach($selectedIds as $v){
               $this->AuftragPaidAndLock($v,false);
             }
+            $msg = $this->app->erp->base64_url_encode('<div class="success">Ausgewählte Aufträge wurden als bezahlt markiert und wieder gesperrt.</div>');
+            $this->app->Location->execute('index.php?module=auftrag&action=list&msg='.$msg);
           break;
           case 'versandentfernen':
             if(!empty($selectedIds)) {

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -6987,9 +6987,14 @@ Die Gesamtsumme stimmt nicht mehr mit urspr&uuml;nglich festgelegten Betrag '.
             }
           break;
           case 'paidlock':
+            if(empty($selectedIds)){
+              break;
+            }
             foreach($selectedIds as $v){
               $this->AuftragPaidAndLock($v,false);
             }
+            $msg = $this->app->erp->base64_url_encode('<div class="success">Ausgewählte Aufträge wurden als bezahlt markiert und wieder gesperrt.</div>');
+            $this->app->Location->execute('index.php?module=auftrag&action=list&msg='.$msg);
           break;
           case 'versandentfernen':
             if(!empty($selectedIds)) {

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -1901,17 +1901,25 @@ class Auftrag extends GenAuftrag
   /**
    * Entfernt kurzzeitig den Schreibschutz, markiert den Auftrag als bezahlt und setzt den Schreibschutz erneut.
    */
-  public function AuftragPaidAndLock()
+  public function AuftragPaidAndLock($id = null, bool $redirect = true)
   {
-    $id = (int)$this->app->Secure->GetGET('id');
+    if($id === null){
+      $id = (int)$this->app->Secure->GetGET('id');
+    }
 
     if($id <= 0){
-      $this->app->Location->execute('index.php?module=auftrag&action=list');
+      if($redirect){
+        $this->app->Location->execute('index.php?module=auftrag&action=list');
+      }
+      return;
     }
 
     if(!$this->app->erp->RechteVorhanden('auftrag','edit')) {
       $this->app->erp->RunHook('permission_denied', 4, 'auftrag', 'edit');
-      $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+      if($redirect){
+        $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+      }
+      return;
     }
 
     $this->app->DB->Update(
@@ -1929,7 +1937,9 @@ class Auftrag extends GenAuftrag
     );
     $this->app->erp->AuftragProtokoll($id,'Schreibschutz nach Bezahlmarkierung gesetzt');
 
-    $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+    if($redirect){
+      $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
+    }
   }
 
   /**
@@ -6974,6 +6984,11 @@ Die Gesamtsumme stimmt nicht mehr mit urspr&uuml;nglich festgelegten Betrag '.
           case 'versandfreigeben':
             if(!empty($selectedIds)) {
               $this->app->DB->Update('UPDATE auftrag SET autoversand = 1 WHERE id IN ('. implode(', ', $selectedIds) . ')');
+            }
+          break;
+          case 'paidlock':
+            foreach($selectedIds as $v){
+              $this->AuftragPaidAndLock($v,false);
             }
           break;
           case 'versandentfernen':

--- a/www/pages/auftrag.php
+++ b/www/pages/auftrag.php
@@ -1915,7 +1915,6 @@ class Auftrag extends GenAuftrag
     }
 
     if(!$this->app->erp->RechteVorhanden('auftrag','edit')) {
-      $this->app->erp->RunHook('permission_denied', 4, 'auftrag', 'edit');
       if($redirect){
         $this->app->Location->execute('index.php?module=auftrag&action=edit&id='.$id);
       }
@@ -1928,7 +1927,7 @@ class Auftrag extends GenAuftrag
     $this->app->erp->AuftragProtokoll($id,'Schreibschutz fuer Bezahlmarkierung entfernt');
 
     $this->app->DB->Update(
-      sprintf("UPDATE auftrag SET vorabbezahltmarkieren = 1, saldogeprueft = 1 WHERE id = %d LIMIT 1", $id)
+      sprintf("UPDATE auftrag SET vorabbezahltmarkieren = 1, saldogeprueft = NOW() WHERE id = %d LIMIT 1", $id)
     );
     $this->app->erp->AuftragProtokoll($id,'Auftrag manuell als bezahlt markiert');
 

--- a/www/pages/content/auftraguebersicht.tpl
+++ b/www/pages/content/auftraguebersicht.tpl
@@ -90,6 +90,7 @@ document.onkeydown = function(evt) {
 	<option value="versandentfernen">{|Option &quot;F&uuml;r den Versand&quot; entfernen|}</option>
 	<option value="fastlane">{|Option "Fast-Lane" setzen|}</option>
 	<option value="fastlaneentfernen">{|Option &quot;Fast-Lane&quot; entfernen|}</option>
+	<option value="paidlock">{|als bezahlt markieren|}</option>
 	<option value="mail">{|per Mail versenden|}</option>
 	<option value="versendet">{|als versendet markieren|}</option>
 	<option value="stapelproduktionweiter">{|als Produktion weiterf&uuml;hren|}</option>


### PR DESCRIPTION
**Ziel**: Bezahl-Status effizient setzen.
- **Umgesetzt**: Neue Option „als bezahlt markiert“ im Bulk-Editor und in der Auftrags-Detailansicht: Auftrag entsperren, als bezahlt markieren, wieder schreibschützen.
- **Erwartetes Verhalten**: Markierte Aufträge lassen sich schnell als bezahlt setzen, ohne manuelle Zwischenschritte.
