### PR TITLE
Feature/row highlight clean

### DIFF
--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -495,3 +495,14 @@
     color: #DDD;
     background-color: #222;
 }
+
+/* Highlight rows that are marked via the checkbox column */
+table.dataTable tbody tr.row-marked,
+table.display tbody tr.row-marked {
+    background-color: #e8f2ff !important;
+}
+
+table.dataTable tbody tr.row-marked td,
+table.display tbody tr.row-marked td {
+    background-color: #e8f2ff !important;
+}

--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -518,12 +518,26 @@ table.display tbody tr.row-marked td {
  * sets class="odd"/"even" on each tr via JS, so we use that directly
  * instead of pure nth-child which the cascade overrides.
  *
- * .row-marked above still wins because tr.row-marked has equal class count
- * but is defined later AND uses !important. */
-.dataTables_wrapper table.dataTable.display > tbody > tr.even > td {
+ * Markierte Zeilen (.row-marked) werden ueber :not(.row-marked) explizit
+ * vom Striping ausgeschlossen -- ohne diesen Filter wuerde die Stripe-
+ * Regel mit hoeherer Spezifitaet (0,4,4 bzw. 0,5,4) den .row-marked-
+ * Highlight (0,2,4) gewinnen, obwohl beide !important nutzen. */
+.dataTables_wrapper table.dataTable.display > tbody > tr.even:not(.row-marked) > td {
     background-color: #f7f9fb !important;
 }
 
-.dataTables_wrapper table.dataTable.display > tbody > tr.even:nth-child(4n) > td {
+.dataTables_wrapper table.dataTable.display > tbody > tr.even:nth-child(4n):not(.row-marked) > td {
     background-color: #eef3f8 !important;
+}
+
+/* DataTables faerbt die aktuell sortierte Spalte (td.sorting_1/_2/_3) mit
+ * eigener Spezifitaet (0,4,4). In markierten Zeilen wuerde diese Regel
+ * sonst sichtbar bleiben und einen "doppelten Hintergrund" erzeugen
+ * (sortierte Spalte hat andere Farbe als der Rest der Row). Override mit
+ * explizitem Wrapper-Pfad (Spezifitaet 0,5,4) erzwingt einheitlichen
+ * Highlight ueber alle Spalten der markierten Zeile. */
+.dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_1,
+.dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_2,
+.dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_3 {
+    background-color: #e8f2ff !important;
 }

--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -506,3 +506,17 @@ table.dataTable tbody tr.row-marked td,
 table.display tbody tr.row-marked td {
     background-color: #e8f2ff !important;
 }
+
+/* Zebra striping for table readability:
+ *   - every 2nd row: very light blue tint
+ *   - every 4th row: a touch deeper (4n is also even, but defined later so it wins)
+ * .row-marked above keeps authority via !important and overrides both. */
+table.dataTable tbody tr:nth-child(even) td,
+table.display tbody tr:nth-child(even) td {
+    background-color: #f7f9fb;
+}
+
+table.dataTable tbody tr:nth-child(4n) td,
+table.display tbody tr:nth-child(4n) td {
+    background-color: #eef3f8;
+}

--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -510,13 +510,21 @@ table.display tbody tr.row-marked td {
 /* Zebra striping for table readability:
  *   - every 2nd row: very light blue tint
  *   - every 4th row: a touch deeper (4n is also even, but defined later so it wins)
- * .row-marked above keeps authority via !important and overrides both. */
+ *
+ * !important is required because the OpenXE theme stylesheet sets a hard
+ * white background on tr/td which would otherwise win over the nth-child
+ * selectors here. .row-marked above keeps authority because its
+ * specificity (table.dataTable tbody tr.row-marked td) is higher than
+ * the nth-child selectors (table.dataTable tbody tr:nth-child(...) td)
+ * — at equal !important, higher specificity wins. */
 table.dataTable tbody tr:nth-child(even) td,
-table.display tbody tr:nth-child(even) td {
-    background-color: #f7f9fb;
+table.display tbody tr:nth-child(even) td,
+.dataTables_wrapper tbody tr:nth-child(even) td {
+    background-color: #f7f9fb !important;
 }
 
 table.dataTable tbody tr:nth-child(4n) td,
-table.display tbody tr:nth-child(4n) td {
-    background-color: #eef3f8;
+table.display tbody tr:nth-child(4n) td,
+.dataTables_wrapper tbody tr:nth-child(4n) td {
+    background-color: #eef3f8 !important;
 }

--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -508,23 +508,22 @@ table.display tbody tr.row-marked td {
 }
 
 /* Zebra striping for table readability:
- *   - every 2nd row: very light blue tint
- *   - every 4th row: a touch deeper (4n is also even, but defined later so it wins)
+ *   - every 2nd row: very light blue tint  (tr.even = rows 2,4,6,...)
+ *   - every 4th row: a touch deeper        (tr.even at nth-child(4n) = rows 4,8,12,...)
  *
- * !important is required because the OpenXE theme stylesheet sets a hard
- * white background on tr/td which would otherwise win over the nth-child
- * selectors here. .row-marked above keeps authority because its
- * specificity (table.dataTable tbody tr.row-marked td) is higher than
- * the nth-child selectors (table.dataTable tbody tr:nth-child(...) td)
- * — at equal !important, higher specificity wins. */
-table.dataTable tbody tr:nth-child(even) td,
-table.display tbody tr:nth-child(even) td,
-.dataTables_wrapper tbody tr:nth-child(even) td {
+ * Selector matches the OpenXE styles.css rule
+ *   ".dataTables_wrapper table.dataTable.display > tbody > tr > td"
+ * exactly to win the specificity battle (3 classes + 2 combinators, plus
+ * .even adds another class -> beats the white-background rule). DataTables
+ * sets class="odd"/"even" on each tr via JS, so we use that directly
+ * instead of pure nth-child which the cascade overrides.
+ *
+ * .row-marked above still wins because tr.row-marked has equal class count
+ * but is defined later AND uses !important. */
+.dataTables_wrapper table.dataTable.display > tbody > tr.even > td {
     background-color: #f7f9fb !important;
 }
 
-table.dataTable tbody tr:nth-child(4n) td,
-table.display tbody tr:nth-child(4n) td,
-.dataTables_wrapper tbody tr:nth-child(4n) td {
+.dataTables_wrapper table.dataTable.display > tbody > tr.even:nth-child(4n) > td {
     background-color: #eef3f8 !important;
 }

--- a/www/themes/new/css/datatables_custom.css
+++ b/www/themes/new/css/datatables_custom.css
@@ -499,12 +499,12 @@
 /* Highlight rows that are marked via the checkbox column */
 table.dataTable tbody tr.row-marked,
 table.display tbody tr.row-marked {
-    background-color: #e8f2ff !important;
+    background-color: var(--accent-soft, #e8f2ff) !important;
 }
 
 table.dataTable tbody tr.row-marked td,
 table.display tbody tr.row-marked td {
-    background-color: #e8f2ff !important;
+    background-color: var(--accent-soft, #e8f2ff) !important;
 }
 
 /* Zebra striping for table readability:
@@ -523,11 +523,11 @@ table.display tbody tr.row-marked td {
  * Regel mit hoeherer Spezifitaet (0,4,4 bzw. 0,5,4) den .row-marked-
  * Highlight (0,2,4) gewinnen, obwohl beide !important nutzen. */
 .dataTables_wrapper table.dataTable.display > tbody > tr.even:not(.row-marked) > td {
-    background-color: #f7f9fb !important;
+    background-color: var(--surface-alt, #f7f9fb) !important;
 }
 
 .dataTables_wrapper table.dataTable.display > tbody > tr.even:nth-child(4n):not(.row-marked) > td {
-    background-color: #eef3f8 !important;
+    background-color: var(--surface-muted, #eef3f8) !important;
 }
 
 /* DataTables faerbt die aktuell sortierte Spalte (td.sorting_1/_2/_3) mit
@@ -539,5 +539,5 @@ table.display tbody tr.row-marked td {
 .dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_1,
 .dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_2,
 .dataTables_wrapper table.dataTable.display > tbody > tr.row-marked > td.sorting_3 {
-    background-color: #e8f2ff !important;
+    background-color: var(--accent-soft, #e8f2ff) !important;
 }

--- a/www/themes/new/js/scripts.js
+++ b/www/themes/new/js/scripts.js
@@ -134,18 +134,20 @@ $(function() {
     }); 
 
     /* Toggle background for rows that are marked via checkboxes */
-    var markedRowTables = [
-        "#angebote",
-        "#angeboteinbearbeitung",
-        "#auftraege",
-        "#auftraegeoffene",
-        "#auftraegeinbearbeitung",
-        "#rechnungen",
-        "#rechnungenoffene",
-        "#rechnungeninbearbeitung",
-        "#lieferscheine",
-        "#lieferscheineinbearbeitung",
-        "#mahnwesen_list"
+    var markedRowTableIds = [
+        "angebote",
+        "angeboteinbearbeitung",
+        "auftraege",
+        "auftraegeoffene",
+        "auftraegeoffeneauto",
+        "auftraegeinbearbeitung",
+        "rechnungen",
+        "rechnungenoffene",
+        "rechnungeninbearbeitung",
+        "lieferscheine",
+        "lieferscheineoffene",
+        "lieferscheineinbearbeitung",
+        "mahnwesen_list"
     ];
 
     function markSelectedRows($table) {
@@ -156,10 +158,15 @@ $(function() {
         });
     }
 
-    function bindMarkedRowHighlight(selector) {
-        var $table = $(selector);
+    function isMarkedTable($table){
+        var id = $table.attr("id");
+        return id && markedRowTableIds.indexOf(id) !== -1;
+    }
 
-        if(!$table.length){
+    function bindMarkedRowHighlight(selector) {
+        var $table = selector instanceof jQuery ? selector : $(selector);
+
+        if(!$table.length || !isMarkedTable($table)){
             return;
         }
 
@@ -180,12 +187,16 @@ $(function() {
     }
 
     function refreshMarkedRowTables(){
-        markedRowTables.forEach(function(selector){
-            bindMarkedRowHighlight(selector);
+        markedRowTableIds.forEach(function(id){
+            bindMarkedRowHighlight("#" + id);
         });
     }
 
     refreshMarkedRowTables();
+
+    $(document).on("init.dt", function(e, settings){
+        bindMarkedRowHighlight($(settings.nTable));
+    });
 
     $(document).on("change", "#auswahlalle", function(){
         window.setTimeout(refreshMarkedRowTables, 0);
@@ -193,6 +204,5 @@ $(function() {
 
     
 });
-
 
 

--- a/www/themes/new/js/scripts.js
+++ b/www/themes/new/js/scripts.js
@@ -133,9 +133,66 @@ $(function() {
 	   $("body").css("overflow", "visible");
     }); 
 
+    /* Toggle background for rows that are marked via checkboxes */
+    var markedRowTables = [
+        "#angebote",
+        "#angeboteinbearbeitung",
+        "#auftraege",
+        "#auftraegeoffene",
+        "#auftraegeinbearbeitung",
+        "#rechnungen",
+        "#rechnungenoffene",
+        "#rechnungeninbearbeitung",
+        "#lieferscheine",
+        "#lieferscheineinbearbeitung",
+        "#mahnwesen_list"
+    ];
+
+    function markSelectedRows($table) {
+        $table.find("tbody tr").each(function(){
+            var $row = $(this);
+            var isChecked = $row.find('input[type="checkbox"]:checked').length > 0;
+            $row.toggleClass("row-marked", isChecked);
+        });
+    }
+
+    function bindMarkedRowHighlight(selector) {
+        var $table = $(selector);
+
+        if(!$table.length){
+            return;
+        }
+
+        if($table.data("rowMarkedBound")){
+            markSelectedRows($table);
+            return;
+        }
+
+        $table.data("rowMarkedBound", true);
+
+        var refresh = function(){
+            markSelectedRows($table);
+        };
+
+        $table.on("change", "tbody input[type=\"checkbox\"]", refresh);
+        $table.on("draw.dt", refresh);
+        refresh();
+    }
+
+    function refreshMarkedRowTables(){
+        markedRowTables.forEach(function(selector){
+            bindMarkedRowHighlight(selector);
+        });
+    }
+
+    refreshMarkedRowTables();
+
+    $(document).on("change", "#auswahlalle", function(){
+        window.setTimeout(refreshMarkedRowTables, 0);
+    });
+
     
 });
-
 
 
 


### PR DESCRIPTION
- **Ziel**: Markierte Belege sofort erkennbar machen.
- **Umgesetzt**: Markierte Angebote/Aufträge/Rechnungen werden beim Setzen der Checkbox mit einem Hintergrund hervorgehoben; auch nach DataTables-Init gesichert.
- **Erwartetes Verhalten**: Selektierte Zeilen heben sich optisch ab, Selektionsstatus bleibt nach Tabellen-Reload bestehen.