### PR TITLE
Menu configurator

### DIFF
--- a/www/lib/class.erpapi.php
+++ b/www/lib/class.erpapi.php
@@ -6707,14 +6707,178 @@ title: 'Abschicken',
     return $navarray['menu']['tmp'];
   }
 
-  // @refactor Navigation Widget
-  function NavigationENT()
+  /**
+   * @param string     $firstTitle
+   * @param array|null $secnav
+   *
+   * @return string
+   */
+  public function GetMenuConfiguratorKey($firstTitle, $secnav = null)
   {
-    return $this->Navigation();
+    $firstTitle = (string)$firstTitle;
+    if($secnav === null){
+      return 'first|'.$firstTitle;
+    }
+    $secTitle = isset($secnav[0])?(string)$secnav[0]:'';
+    $module = isset($secnav[1])?(string)$secnav[1]:'';
+    $action = isset($secnav[2])?(string)$secnav[2]:'';
+    return 'sec|'.$firstTitle.'|'.$module.'|'.$action.'|'.$secTitle;
+  }
+
+  /**
+   * @param int|null $userId
+   *
+   * @return array
+   */
+  public function GetMenuConfiguratorConfig($userId = null)
+  {
+    $default = ['items' => [], 'applyCustomStructure' => false];
+    if(empty($userId)){
+      $userId = $this->app->User->GetID();
+    }
+    if((int)$userId <= 0){
+      return $default;
+    }
+    try{
+      /** @var \Xentral\Modules\User\Service\UserConfigService $userConfig */
+      $userConfig = $this->app->Container->get('UserConfigService');
+    }
+    catch(Exception $e){
+      return $default;
+    }
+    try{
+      $stored = $userConfig->tryGet('menu_configurator', $userId);
+    }
+    catch(Exception $e){
+      $stored = null;
+    }
+    if(is_string($stored)){
+      $decoded = json_decode($stored, true);
+      if(is_array($decoded)){
+        $stored = $decoded;
+      }
+    }
+    if(!is_array($stored)){
+      return $default;
+    }
+    return array_merge($default, $stored);
+  }
+
+  /**
+   * @param array      $menu
+   * @param array|null $config
+   *
+   * @return array
+   */
+  public function ApplyMenuConfigurator(array $menu, array $config = null)
+  {
+    if(empty($menu)){
+      return $menu;
+    }
+    if($config === null){
+      $config = $this->GetMenuConfiguratorConfig();
+    }
+    $config = array_merge(['items' => [], 'applyCustomStructure' => false], is_array($config)?$config:[]);
+    $configItems = is_array($config['items'])?$config['items']:[];
+    $applyCustomStructure = !empty($config['applyCustomStructure']);
+    $result = [];
+    $defaultTopOrder = 0;
+
+    foreach($menu as $entry){
+      $firstTitle = isset($entry['first'][0])?(string)$entry['first'][0]:'';
+      $firstKey = $this->GetMenuConfiguratorKey($firstTitle);
+      $firstConfig = isset($configItems[$firstKey]) && is_array($configItems[$firstKey])?$configItems[$firstKey]:[];
+      if(array_key_exists('visible', $firstConfig) && $firstConfig['visible'] === false){
+        continue;
+      }
+      $entry['_default_order'] = $defaultTopOrder++;
+      $entry['_custom_order'] = isset($firstConfig['order']) && $firstConfig['order'] !== '' && $firstConfig['order'] !== null?(float)$firstConfig['order']:null;
+      if(!empty($firstConfig['customTitle'])){
+        $entry['first'][0] = $firstConfig['customTitle'];
+      }
+
+      $secList = [];
+      if(isset($entry['sec']) && is_array($entry['sec'])){
+        $defaultSecOrder = 0;
+        foreach($entry['sec'] as $sec){
+          $secKey = $this->GetMenuConfiguratorKey($firstTitle, $sec);
+          $secConfig = isset($configItems[$secKey]) && is_array($configItems[$secKey])?$configItems[$secKey]:[];
+          if(array_key_exists('visible', $secConfig) && $secConfig['visible'] === false){
+            continue;
+          }
+          $sec['_default_order'] = $defaultSecOrder++;
+          $sec['_custom_order'] = isset($secConfig['order']) && $secConfig['order'] !== '' && $secConfig['order'] !== null?(float)$secConfig['order']:null;
+          if(!empty($secConfig['customTitle'])){
+            $sec[0] = $secConfig['customTitle'];
+          }
+          $secList[] = $sec;
+        }
+      }
+
+      if($applyCustomStructure && count($secList) > 1){
+        usort(
+          $secList,
+          static function($a, $b){
+            $orderA = array_key_exists('_custom_order', $a) && $a['_custom_order'] !== null?$a['_custom_order']:$a['_default_order'];
+            $orderB = array_key_exists('_custom_order', $b) && $b['_custom_order'] !== null?$b['_custom_order']:$b['_default_order'];
+            if($orderA == $orderB){
+              return 0;
+            }
+            return $orderA < $orderB?-1:1;
+          }
+        );
+      }
+
+      if(!empty($secList)){
+        foreach($secList as &$secEntry){
+          if(isset($secEntry['_default_order'])){
+            unset($secEntry['_default_order']);
+          }
+          if(isset($secEntry['_custom_order'])){
+            unset($secEntry['_custom_order']);
+          }
+        }
+        unset($secEntry);
+      }
+      $entry['sec'] = $secList;
+      $result[] = $entry;
+    }
+
+    if($applyCustomStructure && count($result) > 1){
+      usort(
+        $result,
+        static function($a, $b){
+          $orderA = array_key_exists('_custom_order', $a) && $a['_custom_order'] !== null?$a['_custom_order']:$a['_default_order'];
+          $orderB = array_key_exists('_custom_order', $b) && $b['_custom_order'] !== null?$b['_custom_order']:$b['_default_order'];
+          if($orderA == $orderB){
+            return 0;
+          }
+          return $orderA < $orderB?-1:1;
+        }
+      );
+    }
+
+    foreach($result as &$entry){
+      if(isset($entry['_default_order'])){
+        unset($entry['_default_order']);
+      }
+      if(isset($entry['_custom_order'])){
+        unset($entry['_custom_order']);
+      }
+    }
+    unset($entry);
+
+    return $result;
   }
 
   // @refactor Navigation Widget
-  function Navigation()
+  function NavigationENT($applyUserConfig = true)
+  {
+    return $this->Navigation($applyUserConfig);
+  }
+
+  // @refactor Navigation Widget
+  function Navigation($applyUserConfig = true)
   {
     // admin menu
     $menu = 0;
@@ -6866,7 +7030,12 @@ title: 'Abschicken',
     // Always the last entry
     $navarray['menu']['admin'][$menu]['sec'][]  = array('Abmelden','welcome','logout');
 
-    return $this->CalculateNavigation($navarray);
+    $calculatedMenu = $this->CalculateNavigation($navarray);
+    if($applyUserConfig){
+      $calculatedMenu = $this->ApplyMenuConfigurator($calculatedMenu);
+    }
+
+    return $calculatedMenu;
   }
 
 

--- a/www/pages/content/welcome_settings.tpl
+++ b/www/pages/content/welcome_settings.tpl
@@ -256,8 +256,19 @@
 			</div>
 		</div>
 
+		<div class="row">
+			<div class="row-height">
+				<div class="col-xs-12 col-md-12 col-md-height">
+					<div class="inside inside-full-height">
+						[MENU_CONFIGURATOR]
+					</div>
+				</div>
+			</div>
+		</div>
+
 	</div>
 </div>
+[MENU_CONFIGURATOR_SCRIPT]
 
 <div id="dialog-confirm" title="Code scannen" style="display:none">
 	<p><span class="ui-icon ui-icon-alert" style="float:left; margin:12px 12px 20px 0;"></span>Bitte scannen Sie den QR-Code mit Google Authenticator oder einer anderen TOTP-App, da Sie sich sonst nicht anmelden können werden!</p>

--- a/www/pages/welcome.php
+++ b/www/pages/welcome.php
@@ -3310,7 +3310,7 @@ $this->app->Tpl->Add('TODOFORUSER',"<tr><td width=\"90%\">".$tmp[$i]['aufgabe'].
    */
   protected function HandleMenuConfiguratorSave()
   {
-    $payload = $this->app->Secure->GetPOST('menu_configurator_payload');
+    $payload = $this->app->Secure->GetPOST('menu_configurator_payload', '', '', 'noescape');
     $menu = $this->app->erp->Navigation(false);
     $allowedKeys = $this->collectMenuConfiguratorKeys($menu);
     $config = ['applyCustomStructure' => false, 'items' => []];

--- a/www/pages/welcome.php
+++ b/www/pages/welcome.php
@@ -3349,7 +3349,7 @@ $this->app->Tpl->Add('TODOFORUSER',"<tr><td width=\"90%\">".$tmp[$i]['aufgabe'].
       /** @var \Xentral\Modules\User\Service\UserConfigService $userConfig */
       $userConfig = $this->app->Container->get('UserConfigService');
       $userConfig->set('menu_configurator', json_encode($config), $this->app->User->GetID());
-      $this->app->Tpl->Set('MESSAGE', $this->app->erp->Meldung('Men&uuml;konfiguration gespeichert.'));
+      $this->app->Tpl->Set('MESSAGE', '<div class="success">Men&uuml;konfiguration gespeichert.</div>');
     }
     catch(Exception $e){
       $this->app->Tpl->Set('MESSAGE', '<div class="error">Men&uuml;konfiguration konnte nicht gespeichert werden.</div>');

--- a/www/pages/welcome.php
+++ b/www/pages/welcome.php
@@ -3318,7 +3318,7 @@ $this->app->Tpl->Add('TODOFORUSER',"<tr><td width=\"90%\">".$tmp[$i]['aufgabe'].
     if($payload !== null && $payload !== ''){
       $decoded = json_decode($payload, true);
       if(!is_array($decoded)){
-        $this->app->Tpl->Set('MESSAGE', $this->app->erp->Fehlermeldung('Men&uuml;konfiguration konnte nicht gespeichert werden. Eingaben waren nicht g&uuml;ltig.'));
+        $this->app->Tpl->Set('MESSAGE', '<div class="error">Men&uuml;konfiguration konnte nicht gespeichert werden. Eingaben waren nicht g&uuml;ltig.</div>');
         return;
       }
       $config['applyCustomStructure'] = !empty($decoded['applyCustomStructure']);
@@ -3352,7 +3352,7 @@ $this->app->Tpl->Add('TODOFORUSER',"<tr><td width=\"90%\">".$tmp[$i]['aufgabe'].
       $this->app->Tpl->Set('MESSAGE', $this->app->erp->Meldung('Men&uuml;konfiguration gespeichert.'));
     }
     catch(Exception $e){
-      $this->app->Tpl->Set('MESSAGE', $this->app->erp->Fehlermeldung('Men&uuml;konfiguration konnte nicht gespeichert werden.'));
+      $this->app->Tpl->Set('MESSAGE', '<div class="error">Men&uuml;konfiguration konnte nicht gespeichert werden.</div>');
     }
   }
 


### PR DESCRIPTION
Fügt einen Menükonfigurator in „Mein Bereich → Einstellungen“ hinzu, um Haupt- und Untermenüpunkte auszublenden, umzubenennen und optional zu sortieren.
Speichert die Konfiguration pro Benutzer in userkonfiguration (Key menu_configurator).
Wendet die Konfiguration beim Generieren der Sidebar-Navigation an (inkl. Sortierung, sofern aktiviert).
Details

Backend: Erweiterung in erpAPI um Menü-Keys, Config‑Lesen und Anwendung (Sichtbarkeit, Titel, Sortierung).
Navigation: Navigation() kann user-spezifische Anpassungen anwenden, Standardverhalten bleibt erhalten, wenn deaktiviert.
Settings: Neue Action menu-configurator-save in welcome.php, die JSON-Payload übernimmt und speichert.
UI: Feldset „Menükonfigurator“ in welcome_settings.tpl mit Tabelle (Bereich, Menüpunkt, Sichtbarkeit, Sortierung, eigener Titel) und Reset-Button; Sortierung greift nur, wenn „Eigene Struktur anwenden (Sortierung)“ aktiv ist.
Sortierlogik

Pro Hauptmenü und pro Untermenüliste; gleiche Zahlen sind erlaubt, leere Felder behalten die Standardreihenfolge.