### PR TITLE
# fix(woocommerce): Varianten-Support und sichere Konfigurationszugriffe

### DIFF
--- a/www/lib/class.remote.php
+++ b/www/lib/class.remote.php
@@ -30,7 +30,8 @@ use Xentral\Modules\Onlineshop\Data\Shipment;
 use Xentral\Modules\Onlineshop\Data\ShopConnectorResponseInterface;
 use Xentral\Components\Logger\Logger;
 
-class Remote {
+class Remote
+{
 
     /** @var ApplicationCore $app */
     public $app;
@@ -38,7 +39,8 @@ class Remote {
     /** @var Logger $logger */
     public $logger;
 
-    public function __construct($app) {
+    public function __construct($app)
+    {
         $this->app = $app;
         $this->logger = $app->Container->get('Logger');
     }
@@ -50,20 +52,21 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteConnection($shopId, $extra = null) {
+    public function RemoteConnection($shopId, $extra = null)
+    {
         $ret = $this->RemoteCommand($shopId, 'auth', $extra);
         if ($ret !== 'success' && empty($extra) && method_exists($this->app->erp, 'setSystemHealth')) {
             $this->app->erp->setSystemHealth(
-                    'shopexport',
-                    'auth',
-                    'warning',
-                    'Verbindung zu ' .
-                    $this->app->DB->Select(
-                            sprintf(
-                                    'SELECT bezeichnung FROM shopexport WHERE id = %d',
-                                    $shopId
-                            )
-                    ) . ' fehlgeschlagen.'
+                'shopexport',
+                'auth',
+                'warning',
+                'Verbindung zu ' .
+                $this->app->DB->Select(
+                    sprintf(
+                        'SELECT bezeichnung FROM shopexport WHERE id = %d',
+                        $shopId
+                    )
+                ) . ' fehlgeschlagen.'
             );
             try {
                 /** @var Systemhealth $systemhealth */
@@ -72,7 +75,7 @@ class Remote {
                     $systemhealth->createEvent('shopexport', 'auth', 'warning', 'shopexport', $shopId);
                 }
             } catch (Exception $d) {
-                
+
             }
         }
         return $ret;
@@ -84,7 +87,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteGetUpdateArticleList($shopId) {
+    public function RemoteGetUpdateArticleList($shopId)
+    {
         return $this->RemoteCommand($shopId, 'getlist');
     }
 
@@ -94,7 +98,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteGetFileList($shopId) {
+    public function RemoteGetFileList($shopId)
+    {
         return $this->RemoteCommand($shopId, 'getfilelist');
     }
 
@@ -105,7 +110,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteGetFileListArticle($shopId, $article) {
+    public function RemoteGetFileListArticle($shopId, $article)
+    {
         $data['artikel'] = $article;
 
         return $this->RemoteCommand($shopId, 'getfilelistarticle', $data);
@@ -118,7 +124,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteGetAuftraegeAnzahl($shopId, $data = '') {
+    public function RemoteGetAuftraegeAnzahl($shopId, $data = '')
+    {
         if (!empty($data)) {
             return $this->RemoteCommand($shopId, 'getauftraegeanzahl', $data);
         }
@@ -170,7 +177,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteGetAuftraegeAnzahlNummer($shopId, $nummer) {
+    public function RemoteGetAuftraegeAnzahlNummer($shopId, $nummer)
+    {
         $data = array('nummer' => $nummer);
 
         return $this->RemoteCommand($shopId, 'getauftraegeanzahl', $data);
@@ -183,17 +191,18 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteGetAuftrag($shopId, $data = null) {
+    public function RemoteGetAuftrag($shopId, $data = null)
+    {
         if (!empty($data)) {
             return $this->RemoteCommand($shopId, 'getauftrag', $data);
         }
         $data = array();
 
         $shopexportArr = $this->app->DB->SelectRow(
-                sprintf(
-                        'SELECT * FROM shopexport WHERE id = %d LIMIT 1',
-                        $shopId
-                )
+            sprintf(
+                'SELECT * FROM shopexport WHERE id = %d LIMIT 1',
+                $shopId
+            )
         );
         $holealle = $shopexportArr['holealle'];
         $holeallestati = $shopexportArr['holeallestati'];
@@ -207,8 +216,10 @@ class Remote {
         if (!empty($zeitraum)) {
             $data['datumvon'] = $zeitraum['datumvon'];
             $data['datumbis'] = $zeitraum['datumbis'];
-            if ($zeitraum['tmpdatumbis'] !== null && $zeitraum['tmpdatumbis'] !== '0000-00-00 00:00:00' &&
-                    strtotime($zeitraum['tmpdatumbis']) > 0) {
+            if (
+                $zeitraum['tmpdatumbis'] !== null && $zeitraum['tmpdatumbis'] !== '0000-00-00 00:00:00' &&
+                strtotime($zeitraum['tmpdatumbis']) > 0
+            ) {
                 $data['datumbis'] = $zeitraum['tmpdatumbis'];
             }
             //if(strtotime($zeitraum[0]['tmpdatumvon']) > 0)$data['datumvon'] = $zeitraum[0]['tmpdatumbis'];
@@ -250,7 +261,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteGetAuftragNummer($shopId, $nummer) {
+    public function RemoteGetAuftragNummer($shopId, $nummer)
+    {
         $holealle = $this->app->DB->Select("SELECT holealle FROM shopexport WHERE id = '$shopId' LIMIT 1");
         if ($holealle) {
             $data = array('nummer' => $nummer);
@@ -267,7 +279,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteSendExportlink($shopId) {
+    public function RemoteSendExportlink($shopId)
+    {
         // passwort erzeugen , daten verschluesseln, wenn passwort neu link an kunden senden
         // alternativ artikel umfrage
         //    $all = $this->app->DB->SelectArr("SELECT * FROM artikelgruppen WHERE shop='$id'");
@@ -335,7 +348,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteSendNavigation($shopId) {
+    public function RemoteSendNavigation($shopId)
+    {
         //$data[0] = array('aasas','asddd');
 
         $all = $this->app->DB->SelectArr("SELECT * FROM shopnavigation WHERE shop='$shopId'");
@@ -361,7 +375,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteSendArtikelgruppen($shopId) {
+    public function RemoteSendArtikelgruppen($shopId)
+    {
         $all = $this->app->DB->SelectArr("SELECT id, bezeichnung,bezeichnung_en,beschreibung_de,beschreibung_en 
       FROM artikelgruppen WHERE shop='$shopId'");
         if (empty($all)) {
@@ -377,7 +392,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteSendInhalt($shopId) {
+    public function RemoteSendInhalt($shopId)
+    {
         $all = $this->app->DB->SelectArr("SELECT * FROM inhalt WHERE shop='$shopId' AND aktiv=1");
         if (empty($all)) {
             return '';
@@ -411,7 +427,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteSendArtikelArtikelgruppen($shopId) {
+    public function RemoteSendArtikelArtikelgruppen($shopId)
+    {
         $all = $this->app->DB->SelectArr('SELECT * FROM artikel_artikelgruppe');
         $call = $all ? count($all) : 0;
         if ($call > 0) {
@@ -437,7 +454,8 @@ class Remote {
      *
      * @return mixed
      */
-    public function GetShopexportMappingExt($shopId, $tabelle, $intid, $intid2 = 0) {
+    public function GetShopexportMappingExt($shopId, $tabelle, $intid, $intid2 = 0)
+    {
         return $this->app->DB->Select("SELECT extid 
       FROM shopexport_mapping 
       WHERE shop = '$shopId' AND tabelle = '$tabelle' AND intid = '$intid' " . ($intid2 ? " AND intid2 = '$intid2' " : '') . "  LIMIT 1");
@@ -451,7 +469,8 @@ class Remote {
      *
      * @return mixed
      */
-    protected function GetShopexportMappingInt($shopId, $tabelle, $extid, $intid2 = 0) {
+    protected function GetShopexportMappingInt($shopId, $tabelle, $extid, $intid2 = 0)
+    {
         return $this->app->DB->Select("SELECT intid 
       FROM shopexport_mapping 
       WHERE shop = '$shopId' AND tabelle = '$tabelle' AND extid = '$extid' " . ($intid2 ? " AND intid2 = '$intid2' " : '') . " 
@@ -467,7 +486,8 @@ class Remote {
      *
      * @return mixed
      */
-    public function ShopexportMappingSet($shop, $tabelle, $intid, $extid, $intid2 = 0) {
+    public function ShopexportMappingSet($shop, $tabelle, $intid, $extid, $intid2 = 0)
+    {
         $check = $this->app->DB->Select("SELECT id FROM shopexport_mapping 
       WHERE shop = '$shop' AND tabelle = '$tabelle' AND intid = '$intid' AND intid2 = '$intid2' LIMIT 1");
         if (!$check) {
@@ -488,7 +508,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteGetArticle($id, $nummer, $create = false) {
+    public function RemoteGetArticle($id, $nummer, $create = false)
+    {
         if ($create) {
             $data['nummerintern'] = $nummer;
         } else {
@@ -764,9 +785,11 @@ class Remote {
                         if ($katext == 0 && $v['parent'] == 0) {
                             $katext = $v['id'];
                         }
-                        if (!$this->app->DB->Select("SELECT id 
+                        if (
+                            !$this->app->DB->Select("SELECT id 
               FROM shopexport_kategorien 
-              WHERE shop = '$id' AND extid = '" . $this->app->DB->real_escape_string($v['id']) . "' LIMIT 1")) {
+              WHERE shop = '$id' AND extid = '" . $this->app->DB->real_escape_string($v['id']) . "' LIMIT 1")
+                        ) {
                             $this->app->DB->Insert("INSERT INTO shopexport_kategorien (shop, extid, aktiv,extname,extparent,extsort) VALUES 
             ('$id','" . $this->app->DB->real_escape_string($v['id']) . "','" . (int) $v['aktiv'] . "','" . $this->app->DB->real_escape_string($v['name']) . "','" . $this->app->DB->real_escape_string($v['parent']) . "','" . (int) $v['sort'] . "')");
                         }
@@ -862,12 +885,18 @@ class Remote {
                         }
 
                         $gruppeName = $this->app->DB->real_escape_string($ret['matrixprodukt_gruppe' . $m]);
-                        $query = sprintf("SELECT id FROM matrixprodukt_eigenschaftengruppen_artikel WHERE artikel='%s' AND name='%s'",
-                                $articleid, $gruppeName);
+                        $query = sprintf(
+                            "SELECT id FROM matrixprodukt_eigenschaftengruppen_artikel WHERE artikel='%s' AND name='%s'",
+                            $articleid,
+                            $gruppeName
+                        );
                         $gruppeId = $this->app->DB->Select($query);
                         if (empty($gruppeId)) {
-                            $query = sprintf("SELECT MAX(sort) FROM matrixprodukt_eigenschaftengruppen_artikel WHERE artikel='%s' AND name='%s'",
-                                    $articleid, $gruppeName);
+                            $query = sprintf(
+                                "SELECT MAX(sort) FROM matrixprodukt_eigenschaftengruppen_artikel WHERE artikel='%s' AND name='%s'",
+                                $articleid,
+                                $gruppeName
+                            );
                             $sort = $this->app->DB->Select($query);
                             if (empty($sort)) {
                                 $sort = '0';
@@ -881,12 +910,18 @@ class Remote {
 
                         foreach ($ret['matrixprodukt_optionen' . $m] as $optionBezeichnung) {
                             $optionBezeichnung = $this->app->DB->real_escape_string($optionBezeichnung);
-                            $query = sprintf("SELECT id FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
-                                    $articleid, $optionBezeichnung);
+                            $query = sprintf(
+                                "SELECT id FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
+                                $articleid,
+                                $optionBezeichnung
+                            );
                             $optionId = $this->app->DB->Select($query);
                             if (empty($optionId)) {
-                                $query = sprintf("SELECT MAX(sort) FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
-                                        $articleid, $optionBezeichnung);
+                                $query = sprintf(
+                                    "SELECT MAX(sort) FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
+                                    $articleid,
+                                    $optionBezeichnung
+                                );
                                 $sort = $this->app->DB->Select($query);
                                 if (empty($sort)) {
                                     $sort = '1';
@@ -894,7 +929,11 @@ class Remote {
                                 $query = sprintf("INSERT INTO matrixprodukt_eigenschaftenoptionen_artikel 
                     (artikel, matrixprodukt_eigenschaftenoptionen, aktiv,name,name_ext,sort,erstellt,gruppe,bearbeiter,artikelnummer) 
                     VALUES ('%s','0','1','%s','','%s','NOW()','%s','','')",
-                                        $articleid, $optionBezeichnung, $sort, $gruppeId);
+                                    $articleid,
+                                    $optionBezeichnung,
+                                    $sort,
+                                    $gruppeId
+                                );
                                 $this->app->DB->Insert($query);
                             }
                         }
@@ -908,16 +947,25 @@ class Remote {
                         }
 
                         $optionBezeichnung = $this->app->DB->real_escape_string($ret['matrixprodukt_wert' . $m]);
-                        $query = sprintf("SELECT id FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
-                                $variante_von, $optionBezeichnung);
+                        $query = sprintf(
+                            "SELECT id FROM matrixprodukt_eigenschaftenoptionen_artikel WHERE artikel='%s' AND name='%s'",
+                            $variante_von,
+                            $optionBezeichnung
+                        );
                         $optionId = $this->app->DB->Select($query);
                         if (!empty($optionId)) {
-                            $query = sprintf("SELECT id FROM matrixprodukt_optionen_zu_artikel WHERE artikel='%s' AND option_id='%s'",
-                                    $articleid, $optionId);
+                            $query = sprintf(
+                                "SELECT id FROM matrixprodukt_optionen_zu_artikel WHERE artikel='%s' AND option_id='%s'",
+                                $articleid,
+                                $optionId
+                            );
                             $zuordnungId = $this->app->DB->Select($query);
                             if (empty($zuordnungId)) {
-                                $query = sprintf("INSERT INTO matrixprodukt_optionen_zu_artikel (artikel,option_id) VALUES ('%s','%s')",
-                                        $articleid, $optionId);
+                                $query = sprintf(
+                                    "INSERT INTO matrixprodukt_optionen_zu_artikel (artikel,option_id) VALUES ('%s','%s')",
+                                    $articleid,
+                                    $optionId
+                                );
                                 $this->app->DB->Insert($query);
                             }
                         }
@@ -957,7 +1005,11 @@ class Remote {
                 $query = sprintf("INSERT INTO stueckliste (sort, artikel, referenz, place, layer, stuecklistevonartikel, 
                          menge, firma, wert, bauform, alternative, zachse, xpos, ypos, art) 
             VALUES (%d, %d, '', 'DP', 'Top', %d, %d, 1, '', '', 0, '', '', '', 'et')",
-                        $sort, $articleid, $variante_von, $stuecklistenmenge);
+                    $sort,
+                    $articleid,
+                    $variante_von,
+                    $stuecklistenmenge
+                );
                 $this->app->DB->Insert($query);
             }
 
@@ -1004,16 +1056,27 @@ class Remote {
             }
             if (isset($ret['fremdnummern']) && !empty($ret['fremdnummern'])) {
                 foreach ($ret['fremdnummern'] as $fremdnummer) {
-                    $query = sprintf("SELECT id FROM artikelnummer_fremdnummern WHERE shopid=%d AND nummer='%s' AND bezeichnung='%s' AND aktiv=%d AND artikel=%s",
-                            $id, $this->app->DB->real_escape_string($fremdnummer['nummer']), $this->app->DB->real_escape_string($fremdnummer['bezeichnung']), '1', $articleid);
+                    $query = sprintf(
+                        "SELECT id FROM artikelnummer_fremdnummern WHERE shopid=%d AND nummer='%s' AND bezeichnung='%s' AND aktiv=%d AND artikel=%s",
+                        $id,
+                        $this->app->DB->real_escape_string($fremdnummer['nummer']),
+                        $this->app->DB->real_escape_string($fremdnummer['bezeichnung']),
+                        '1',
+                        $articleid
+                    );
                     $fremdnummerfehlt = empty($this->app->DB->Select($query));
 
                     if ($fremdnummerfehlt) {
                         $query = sprintf("INSERT INTO artikelnummer_fremdnummern 
                 (artikel, bezeichnung, nummer, shopid, bearbeiter, aktiv)  VALUES 
                 (%d,'%s','%s',%d,'%s',%d)",
-                                $articleid, $this->app->DB->real_escape_string($fremdnummer['bezeichnung']),
-                                $this->app->DB->real_escape_string($fremdnummer['nummer']), $id, $this->app->User->GetName(), 1);
+                            $articleid,
+                            $this->app->DB->real_escape_string($fremdnummer['bezeichnung']),
+                            $this->app->DB->real_escape_string($fremdnummer['nummer']),
+                            $id,
+                            $this->app->User->GetName(),
+                            1
+                        );
                         $this->app->DB->Insert($query);
                     }
                 }
@@ -1037,7 +1100,8 @@ class Remote {
      *
      * @return array
      */
-    protected function getShopKatgeorien($shopId, $parent = 0, $lvl = 0) {
+    protected function getShopKatgeorien($shopId, $parent = 0, $lvl = 0)
+    {
         if ($lvl > 20) {
             return [];
         }
@@ -1084,18 +1148,21 @@ class Remote {
      * )  
      *
      */
-    public function RemoteSendArticleList($id, $artikel_arr, $extnummer = '', $nurlager = false) {
+    public function RemoteSendArticleList($id, $artikel_arr, $extnummer = '', $nurlager = false)
+    {
 
         $this->logger->debug(
-                'RemoteSendArticleList',
-                [
-                    'shop' => $id,
-                    'artikel_arr' => $artikel_arr
-                ]
+            'RemoteSendArticleList',
+            [
+                'shop' => $id,
+                'artikel_arr' => $artikel_arr
+            ]
         );
 
-        if (!class_exists('ObjGenArtikel') &&
-                is_file(dirname(__DIR__) . '/objectapi/mysql/_gen/object.gen.artikel.php')) {
+        if (
+            !class_exists('ObjGenArtikel') &&
+            is_file(dirname(__DIR__) . '/objectapi/mysql/_gen/object.gen.artikel.php')
+        ) {
             include_once dirname(__DIR__) . '/objectapi/mysql/_gen/object.gen.artikel.php';
         }
         $shopexportarr = $this->app->DB->SelectRow("SELECT * FROM shopexport WHERE id='$id' LIMIT 1");
@@ -1119,7 +1186,7 @@ class Remote {
         ];
 
         if (
-                ($nurlager || empty($artikelexport)) && !empty($shopexportarr['modulename']) && !is_file(dirname(__DIR__) . '/pages/' . $shopexportarr['modulename'] . '_custom.php')
+            ($nurlager || empty($artikelexport)) && !empty($shopexportarr['modulename']) && !is_file(dirname(__DIR__) . '/pages/' . $shopexportarr['modulename'] . '_custom.php')
         ) {
             $elementsNotNeededByModule = ShopimporterBase::storageNotNeededElements($shopexportarr['modulename']);
             foreach ($elementsNotNeededByModule as $element) {
@@ -1385,7 +1452,8 @@ class Remote {
                             'id' => $datei['id'],
                             'version' => $datei['version'],
                             'stichwort' => $datei['subjekt'],
-                            'extid' => $this->GetShopexportMappingExt($id, 'datei', $datei['id']));
+                            'extid' => $this->GetShopexportMappingExt($id, 'datei', $datei['id'])
+                        );
                     }
                 }
                 $dateiengeloescht = $this->app->DB->SelectArr("SELECT s.extid FROM shopexport_mapping s LEFT JOIN datei d ON s.intid = d.id AND d.geloescht = 0 WHERE s.shop = '$id' AND s.tabelle = 'datei' AND s.intid2 = '$artikel' AND isnull(d.id)");
@@ -1440,24 +1508,25 @@ class Remote {
                 $data[$i]['anzahl_lager'] = '';
                 $data[$i]['pseudolager'] = '';
                 $this->app->DB->Update(
-                        sprintf(
-                                'UPDATE `artikel_onlineshops` 
+                    sprintf(
+                        'UPDATE `artikel_onlineshops` 
             SET `storage_cache` = NULL, `pseudostorage_cache` = NULL 
             WHERE `artikel` = %d AND `shop` = %d',
-                                $artikel, $id
-                        )
+                        $artikel,
+                        $id
+                    )
                 );
             } else {
                 $this->app->DB->Update(
-                        sprintf(
-                                'UPDATE `artikel_onlineshops` 
+                    sprintf(
+                        'UPDATE `artikel_onlineshops` 
             SET `storage_cache` = %d, `pseudostorage_cache` = %s 
             WHERE `artikel` = %d AND `shop` = %d',
-                                $data[$i]['anzahl_lager'],
-                                !isset($data[$i]['pseudolager']) || !is_numeric($data[$i]['pseudolager']) ? 'NULL' : $data[$i]['pseudolager'],
-                                $artikel,
-                                $id
-                        )
+                        $data[$i]['anzahl_lager'],
+                        !isset($data[$i]['pseudolager']) || !is_numeric($data[$i]['pseudolager']) ? 'NULL' : $data[$i]['pseudolager'],
+                        $artikel,
+                        $id
+                    )
                 );
             }
 
@@ -1498,8 +1567,12 @@ class Remote {
             if (!empty($loadElements['article_descriptions']) && $this->app->erp->ModulVorhanden('artikel_texte')) {
                 $sprachen = ['de', 'en'];
                 foreach ($sprachen as $sprache) {
-                    $query = sprintf("SELECT * FROM artikel_texte WHERE shop=%d AND sprache='%s' AND artikel=%d AND aktiv=1 LIMIT 1",
-                            $id, strtoupper($sprache), $artikel);
+                    $query = sprintf(
+                        "SELECT * FROM artikel_texte WHERE shop=%d AND sprache='%s' AND artikel=%d AND aktiv=1 LIMIT 1",
+                        $id,
+                        strtoupper($sprache),
+                        $artikel
+                    );
                     $ersetzeStandardbeschreibung = $this->app->DB->SelectRow($query);
                     if (!empty($ersetzeStandardbeschreibung)) {
                         $data[$i]['name_' . $sprache] = $ersetzeStandardbeschreibung['name'];
@@ -1652,7 +1725,7 @@ class Remote {
                     $nurlager = true;
                 } else {
                     $this->app->erp->Systemlog(
-                            'Shopexport bei Artikel ' . $data[$i]['nummer'] . ' ' . $data[$i]['name_de'] . ' fehlgeschlagen, da Verkaufspreis fehlt.'
+                        'Shopexport bei Artikel ' . $data[$i]['nummer'] . ' ' . $data[$i]['name_de'] . ' fehlgeschlagen, da Verkaufspreis fehlt.'
                     );
                     $data[$i]['artikel'] = 'ignore';
                 }
@@ -1772,16 +1845,29 @@ class Remote {
                         if ($matrixStock < 0) {
                             $matrixStock = 0;
                         }
-                        $data[$i]['matrix_varianten']['artikel'][$eigenschaft['artikel']][] = array('zolltarifnummer' => $eigenschaft['zolltarifnummer'], 'gewicht' => $eigenschaft['gewicht'],
-                                    'artikel' => $eigenschaft['artikel'], 'preis' => $eigenschaft['preis'], 'gesperrt' => $eigenschaft['gesperrt'],
-                                    'nummer' => $eigenschaft['nummer'], 'lieferzeitmanuell' => $eigenschaft['lieferzeitmanuell'],
-                                    'altersfreigabe' => $eigenschaft['altersfreigabe'], 'ean' => $eigenschaft['ean'],
-                                    'lag' => $matrixStock,
-                                    'pseudolager' => $matrixPseudoStorage, 'pseudopreis' => $eigenschaft['pseudopreis'],
-                                    'restmenge' => $eigenschaft['restmenge'], 'steuersatz' => ($steuer - 1) * 100, 'umsatzsteuer' => $eigenschaft['umsatzsteuer'],
-                                    'bruttopreis' => $eigenschaft['preis'] * $steuer, 'inaktiv' => $eigenschaft['inaktiv'],
-                                    'name_de' => $eigenschaft['name_de'], 'name_en' => $eigenschaft['name_en'],
-                                    'uebersicht_de' => $eigenschaft['uebersicht_de'], 'uebersicht_en' => $eigenschaft['uebersicht_en']);
+                        $data[$i]['matrix_varianten']['artikel'][$eigenschaft['artikel']][] = array(
+                            'zolltarifnummer' => $eigenschaft['zolltarifnummer'],
+                            'gewicht' => $eigenschaft['gewicht'],
+                            'artikel' => $eigenschaft['artikel'],
+                            'preis' => $eigenschaft['preis'],
+                            'gesperrt' => $eigenschaft['gesperrt'],
+                            'nummer' => $eigenschaft['nummer'],
+                            'lieferzeitmanuell' => $eigenschaft['lieferzeitmanuell'],
+                            'altersfreigabe' => $eigenschaft['altersfreigabe'],
+                            'ean' => $eigenschaft['ean'],
+                            'lag' => $matrixStock,
+                            'pseudolager' => $matrixPseudoStorage,
+                            'pseudopreis' => $eigenschaft['pseudopreis'],
+                            'restmenge' => $eigenschaft['restmenge'],
+                            'steuersatz' => ($steuer - 1) * 100,
+                            'umsatzsteuer' => $eigenschaft['umsatzsteuer'],
+                            'bruttopreis' => $eigenschaft['preis'] * $steuer,
+                            'inaktiv' => $eigenschaft['inaktiv'],
+                            'name_de' => $eigenschaft['name_de'],
+                            'name_en' => $eigenschaft['name_en'],
+                            'uebersicht_de' => $eigenschaft['uebersicht_de'],
+                            'uebersicht_en' => $eigenschaft['uebersicht_en']
+                        );
                         if ($freifelder) {
                             foreach ($freifelder as $freifeld) {
                                 $data[$i]['matrix_varianten']['artikel'][$eigenschaft['artikel']][count($data[$i]['matrix_varianten']['artikel'][$eigenschaft['artikel']]) - 1]['freifelder']['DE'][$freifeld['freifeld_shop']] = $this->app->DB->Select('SELECT ' . $freifeld['freifeld_wawi'] . ' FROM artikel WHERE id=' . $eigenschaft['artikel']);
@@ -1936,14 +2022,13 @@ class Remote {
                     if (empty($data)) {
                         continue;
                     }
-        } while (count($data[$i]['matrix_varianten']['artikel'] ?? [])>=5000);
+                } while (count($data[$i]['matrix_varianten']['artikel'] ?? []) >= 5000);
 
                 // Bulk transfer (new 2024-06-28)
                 $result = null;
                 if (!empty($artikelexport) && !$nurlager) {
                     $result = $this->sendlist($id, $data, true);
-                }
-                else if (!empty($lagerexport)) {
+                } else if (!empty($lagerexport)) {
                     $result = $this->sendlistlager($id, $data);
                 }
                 return $result;
@@ -1974,8 +2059,12 @@ class Remote {
                         if (!empty($loadElements['translations']) && $this->app->erp->ModulVorhanden('artikel_texte')) {
                             $sprachen = ['de', 'en'];
                             foreach ($sprachen as $sprache) {
-                                $query = sprintf("SELECT * FROM artikel_texte WHERE shop=%d AND sprache='%s' AND artikel=%d AND aktiv=1 LIMIT 1",
-                                        $id, strtoupper($sprache), $v['id']);
+                                $query = sprintf(
+                                    "SELECT * FROM artikel_texte WHERE shop=%d AND sprache='%s' AND artikel=%d AND aktiv=1 LIMIT 1",
+                                    $id,
+                                    strtoupper($sprache),
+                                    $v['id']
+                                );
                                 $ersetzeStandardbeschreibung = $this->app->DB->SelectRow($query);
                                 if (!empty($ersetzeStandardbeschreibung)) {
                                     $v['name_' . $sprache] = $ersetzeStandardbeschreibung['name'];
@@ -1988,21 +2077,35 @@ class Remote {
                         }
                         $projectStockId = $this->app->DB->Select("SELECT `id` FROM `projekt` WHERE `id` = '{$projekt}' AND `projektlager` = 1 LIMIT 1");
                         $stock = (float) $this->app->erp->ArtikelAnzahlVerkaufbar(
-                                        $v['id'],
-                                        0,
-                                        $projectStockId,
-                                        $id,
-                                        $lagergrundlage
+                            $v['id'],
+                            0,
+                            $projectStockId,
+                            $id,
+                            $lagergrundlage
                         );
                         if ($stock < 0) {
                             $stock = 0;
                         }
-                        $data[$i]['artikel_varianten'][] = array('nummer' => $v['nummer'], 'name_de' => $v['name_de'], 'name_en' => $v['name_en'], 'restmenge' => $v['restmenge'], 'gesperrt' => ($v['gesperrt'] == 1 || $v['intern_gesperrt'] == 1 ? 1 : 0),
-                            'artikel' => $v['id'], 'zolltarifnummer' => $v['zolltarifnummer'], 'ean' => $v['ean'], 'gewicht' => $v['gewicht'], 'inaktiv' => $v['inaktiv'], 'uebersicht_de' => $v['uebersicht_de'],
+                        $data[$i]['artikel_varianten'][] = array(
+                            'nummer' => $v['nummer'],
+                            'name_de' => $v['name_de'],
+                            'name_en' => $v['name_en'],
+                            'restmenge' => $v['restmenge'],
+                            'gesperrt' => ($v['gesperrt'] == 1 || $v['intern_gesperrt'] == 1 ? 1 : 0),
+                            'artikel' => $v['id'],
+                            'zolltarifnummer' => $v['zolltarifnummer'],
+                            'ean' => $v['ean'],
+                            'gewicht' => $v['gewicht'],
+                            'inaktiv' => $v['inaktiv'],
+                            'uebersicht_de' => $v['uebersicht_de'],
                             'lag' => $stock,
-                            'pseudolager' => $v['pseudolager'], 'pseudopreis' => $v['pseudopreis'], 'preis' => $variantennettopreis, 'bruttopreis' => $variantennettopreis * $steuer,
+                            'pseudolager' => $v['pseudolager'],
+                            'pseudopreis' => $v['pseudopreis'],
+                            'preis' => $variantennettopreis,
+                            'bruttopreis' => $variantennettopreis * $steuer,
                             'artikelnummer_fremdnummern' => $this->app->DB->SelectArr("SELECT * FROM artikelnummer_fremdnummern WHERE artikel = '" . $v['id'] . "' AND nummer <> '' AND shopid = '$id' AND aktiv = '1'"),
-                            'steuersatz' => ($steuer - 1) * 100);
+                            'steuersatz' => ($steuer - 1) * 100
+                        );
                         if (!empty($data[$i]['artikel_varianten'][count($data[$i]['artikel_varianten']) - 1]['artikelnummer_fremdnummern'])) {
                             foreach ($data[$i]['artikel_varianten'][count($data[$i]['artikel_varianten']) - 1]['artikelnummer_fremdnummern'] as $fkey => $fval) {
                                 $data[$i]['artikel_varianten'][count($data[$i]['artikel_varianten']) - 1]['artikelnummer_fremdnummern'][$fkey]['nummer'] = trim($fval['nummer']);
@@ -2068,8 +2171,7 @@ class Remote {
         $result = null;
         if (!empty($artikelexport) && !$nurlager) {
             $result = $this->sendlist($id, $data, true);
-        }
-        else if (!empty($lagerexport)) {
+        } else if (!empty($lagerexport)) {
             $result = $this->sendlistlager($id, $data);
         }
         return $result;
@@ -2079,7 +2181,8 @@ class Remote {
      * @param int $articleId
      * @return array|null
      */
-    protected function getImagesForArticle($articleId) {
+    protected function getImagesForArticle($articleId)
+    {
         $query = sprintf("SELECT d.id AS `id`, dv.id AS `vid`, d.titel, d.beschreibung, ds.subjekt, ds.sort, dv.version AS `version`
                 FROM `datei_stichwoerter` AS `ds` 
                 INNER JOIN `datei` AS `d` ON ds.datei = d.id  
@@ -2091,15 +2194,17 @@ class Remote {
         return $this->app->DB->SelectArr($query);
     }
 
-    protected function sendlistlager(int $shop_id, array $data) {
-        $result = $this->RemoteCommand($shop_id, 'sendlistlager', $data);    
+    protected function sendlistlager(int $shop_id, array $data)
+    {
+        $result = $this->RemoteCommand($shop_id, 'sendlistlager', $data);
         return $result;
     }
 
-    protected function sendlist(int $shop_id, array $data, $isLagerExported) {
+    protected function sendlist(int $shop_id, array $data, $isLagerExported)
+    {
 
         // See description of return format in function RemoteSendArticleList()
-        $result = $this->RemoteCommand($shop_id, 'sendlist', $data);       
+        $result = $this->RemoteCommand($shop_id, 'sendlist', $data);
 
         if (!empty($result) && is_array($result)) {
             /** @var ArticleExportResult $articleResult */
@@ -2110,29 +2215,33 @@ class Remote {
                 $objShopexport = $this->app->loadModule('shopexport');
                 $changedHash = $objShopexport->hasArticleHashChanged($articleResult->articleId, $shop_id);
                 $hash = $changedHash['hash'];
-               
+
                 $checkAo = $this->app->DB->Select(
-                        sprintf(
-                                'SELECT id FROM artikel_onlineshops WHERE artikel = %d AND shop=%d LIMIT 1',
-                            $articleResult->articleId, $shop_id
-                        )
+                    sprintf(
+                        'SELECT id FROM artikel_onlineshops WHERE artikel = %d AND shop=%d LIMIT 1',
+                        $articleResult->articleId,
+                        $shop_id
+                    )
                 );
                 if (empty($checkAo)) {
                     $this->app->DB->Insert(
-                            sprintf(
-                                    'INSERT INTO artikel_onlineshops (artikel, shop, aktiv, ausartikel) 
+                        sprintf(
+                            'INSERT INTO artikel_onlineshops (artikel, shop, aktiv, ausartikel) 
                     VALUES (%d, %d, 1, 1) ',
-                                $articleResult->articleId, $shop_id
-                            )
+                            $articleResult->articleId,
+                            $shop_id
+                        )
                     );
                 }
                 $this->app->DB->Update(
-                        sprintf(
-                                "UPDATE artikel_onlineshops 
+                    sprintf(
+                        "UPDATE artikel_onlineshops 
                   SET last_article_transfer = NOW(), last_article_hash = '%s' 
                   WHERE artikel = %d AND shop = %d",
-                                $this->app->DB->real_escape_string($hash), $articleResult->articleId, $shop_id
-                        )
+                        $this->app->DB->real_escape_string($hash),
+                        $articleResult->articleId,
+                        $shop_id
+                    )
                 );
 
                 $artikelnummer = $this->app->DB->Select("SELECT nummer FROM artikel WHERE id = '$articleResult->articleId' LIMIT 1");
@@ -2141,16 +2250,18 @@ class Remote {
                     WHERE artikel = '$articleResult->articleId'
                     AND shopid = '$shop_id'
                     AND nummer != ''
-                    AND (aktiv = 1 OR nummer = '".trim($this->app->DB->real_escape_string($articleResult->extArticleId))."') LIMIT 1 ");
-                if ($articleResult->articleId > 0 && $articleResult->extArticleId != null &&
+                    AND (aktiv = 1 OR nummer = '" . trim($this->app->DB->real_escape_string($articleResult->extArticleId)) . "') LIMIT 1 ");
+                if (
+                    $articleResult->articleId > 0 && $articleResult->extArticleId != null &&
                     trim($articleResult->extArticleId) != '' &&
                     $artikelnummer != trim($articleResult->extArticleId) &&
-                    empty($artikelfremdnummer)) {
+                    empty($artikelfremdnummer)
+                ) {
                     //Nur falls keine aktive Fremdnummer exisitert.
                     $this->app->DB->Insert("INSERT INTO `artikelnummer_fremdnummern` (artikel, bezeichnung, nummer, shopid, bearbeiter, zeitstempel, aktiv)
                         VALUES ($articleResult->articleId,'Erstellt durch Artikelexport','" . trim($this->app->DB->real_escape_string($articleResult->extArticleId)) . "','$shop_id','" . ((isset($this->app->User) && method_exists($this->app->User, 'GetName')) ? $this->app->DB->real_escape_string($this->app->User->GetName()) : 'Cronjob') . "',now(),0)
                         ");
-                    }
+                }
             }
         }
 
@@ -2160,27 +2271,27 @@ class Remote {
         return $result;
     }
 
-  public function getDataToSendForUpdateOrder(int $shopId, int $orderId): ?OrderStatusUpdateRequest
-  {
-      $orderArr = $this->app->DB->SelectRow("SELECT `zahlungsweise`, `shopextid` FROM `auftrag` WHERE `id` = $orderId LIMIT 1");
-      if (empty($orderArr))
-          return null;
+    public function getDataToSendForUpdateOrder(int $shopId, int $orderId): ?OrderStatusUpdateRequest
+    {
+        $orderArr = $this->app->DB->SelectRow("SELECT `zahlungsweise`, `shopextid` FROM `auftrag` WHERE `id` = $orderId LIMIT 1");
+        if (empty($orderArr))
+            return null;
 
-      $data = new OrderStatusUpdateRequest();
-      $data->orderId = $orderId;
-      $data->shopOrderId = $orderArr['shopextid'];
+        $data = new OrderStatusUpdateRequest();
+        $data->orderId = $orderId;
+        $data->shopOrderId = $orderArr['shopextid'];
 
-      $statusArr = $this->app->DB->SelectFirstCols("SELECT DISTINCT status FROM auftrag WHERE id = $orderId OR teillieferungvon = $orderId");
-      if (in_array('storniert', $statusArr))
-          $data->orderStatus = OrderStatus::Cancelled;
-      if (in_array('abgeschlossen', $statusArr))
-          $data->orderStatus = OrderStatus::Completed;
-      if (in_array('freigegeben', $statusArr))
-          $data->orderStatus = OrderStatus::InProgress;
-      if (in_array('angelegt', $statusArr))
-          $data->orderStatus = OrderStatus::Imported;
+        $statusArr = $this->app->DB->SelectFirstCols("SELECT DISTINCT status FROM auftrag WHERE id = $orderId OR teillieferungvon = $orderId");
+        if (in_array('storniert', $statusArr))
+            $data->orderStatus = OrderStatus::Cancelled;
+        if (in_array('abgeschlossen', $statusArr))
+            $data->orderStatus = OrderStatus::Completed;
+        if (in_array('freigegeben', $statusArr))
+            $data->orderStatus = OrderStatus::InProgress;
+        if (in_array('angelegt', $statusArr))
+            $data->orderStatus = OrderStatus::Imported;
 
-      $sql = "
+        $sql = "
         SELECT DISTINCT
             v.id,
             v.tracking,
@@ -2201,17 +2312,17 @@ class Remote {
         WHERE (a.id = $orderId OR a.teillieferungvon = $orderId) AND v.id IS NOT NULL
         ORDER BY v.id";
 
-      $shipments = $this->app->DB->SelectArr($sql);
-      foreach ($shipments as $shipment) {
-          $item = new Shipment();
-          $item->id = $shipment['id'];
-          $item->trackingNumber = $shipment['tracking'];
-          $item->trackingUrl = $shipment['tracking_link'];
-          $item->shippingMethod = $shipment['versandart'];
-          $data->shipments[] = $item;
-      }
+        $shipments = $this->app->DB->SelectArr($sql);
+        foreach ($shipments as $shipment) {
+            $item = new Shipment();
+            $item->id = $shipment['id'];
+            $item->trackingNumber = $shipment['tracking'];
+            $item->trackingUrl = $shipment['tracking_link'];
+            $item->shippingMethod = $shipment['versandart'];
+            $data->shipments[] = $item;
+        }
 
-      return $data;
+        return $data;
     }
 
     /**
@@ -2220,39 +2331,41 @@ class Remote {
      *
      * @throws Exception
      */
-    public function RemoteUpdateAuftrag($shopId, $orderId) {
-      $data = $this->getDataToSendForUpdateOrder((int)$shopId, (int)$orderId);
-      if($data?->orderStatus !== OrderStatus::Completed)
-          return;
+    public function RemoteUpdateAuftrag($shopId, $orderId)
+    {
+        $data = $this->getDataToSendForUpdateOrder((int) $shopId, (int) $orderId);
+        if ($data?->orderStatus !== OrderStatus::Completed)
+            return;
 
-            $bearbeiter = 'Cronjob';
-            if (isset($this->app->User)) {
-                $bearbeiter = $this->app->DB->real_escape_string($this->app->User->GetName());
-            }
+        $bearbeiter = 'Cronjob';
+        if (isset($this->app->User)) {
+            $bearbeiter = $this->app->DB->real_escape_string($this->app->User->GetName());
+        }
 
-            $response = $this->RemoteCommand($shopId, 'updateauftrag', $data);
-            if ($response instanceOf ShopConnectorResponseInterface && !$response->isSuccessful()) {
-                $query = sprintf('UPDATE `auftrag`
+        $response = $this->RemoteCommand($shopId, 'updateauftrag', $data);
+        if ($response instanceof ShopConnectorResponseInterface && !$response->isSuccessful()) {
+            $query = sprintf('UPDATE `auftrag`
             SET `shop_status_update_attempt` = `shop_status_update_attempt` + 1,
                 `shop_status_update_last_attempt_at` = NOW()
             WHERE `id` = %d', $orderId);
-                $this->app->DB->Update($query);
+            $this->app->DB->Update($query);
 
-                $this->app->erp->AuftragProtokoll($orderId, 'Versandmeldung an Shop fehlgeschlagen', $bearbeiter);
+            $this->app->erp->AuftragProtokoll($orderId, 'Versandmeldung an Shop fehlgeschlagen', $bearbeiter);
 
-                $this->logger->error('Versandmeldung an Shop fehlgeschlagen',
-                    [
-                        'orderId' => $orderId,
-                        'shopId' => $shopId,
-                        'message' => $response->getMessage()
-                    ]
-                );
-                return;
-            }
-
-            $this->app->erp->AuftragProtokoll($orderId, 'Versandmeldung an Shop &uuml;bertragen', $bearbeiter);
-            $this->app->DB->Update("UPDATE `auftrag` SET `shopextstatus` = 'abgeschlossen' WHERE `id` = $orderId LIMIT 1");
+            $this->logger->error(
+                'Versandmeldung an Shop fehlgeschlagen',
+                [
+                    'orderId' => $orderId,
+                    'shopId' => $shopId,
+                    'message' => $response->getMessage()
+                ]
+            );
+            return;
         }
+
+        $this->app->erp->AuftragProtokoll($orderId, 'Versandmeldung an Shop &uuml;bertragen', $bearbeiter);
+        $this->app->DB->Update("UPDATE `auftrag` SET `shopextstatus` = 'abgeschlossen' WHERE `id` = $orderId LIMIT 1");
+    }
 
     /**
      * @param int    $shopId
@@ -2262,7 +2375,8 @@ class Remote {
      *
      * @throws Exception
      */
-    public function RemoteDeleteAuftrag($shopId, $auftrag, $internet = '') {
+    public function RemoteDeleteAuftrag($shopId, $auftrag, $internet = '')
+    {
         $data['auftrag'] = $auftrag;
         $data['internet'] = $internet;
         $this->RemoteCommand($shopId, 'deleteauftrag', $data);
@@ -2274,7 +2388,8 @@ class Remote {
      *
      * @throws Exception
      */
-    public function RemoteStorniereAuftrag($shopId, $orderId) {
+    public function RemoteStorniereAuftrag($shopId, $orderId)
+    {
         $orderArr = $this->app->DB->SelectRow("SELECT shopextid, internet FROM auftrag WHERE id='$orderId' LIMIT 1");
         if (empty($orderArr)) {
             return;
@@ -2284,7 +2399,8 @@ class Remote {
         $data['auftrag'] = $shopextid;
         $data['internet'] = $internet;
 
-        $this->app->DB->Insert("
+        $this->app->DB->Insert(
+            "
     INSERT INTO auftrag_protokoll (auftrag, zeit, bearbeiter, grund) 
     VALUES ($orderId,now(),'" . (isset($this->app->User) ? $this->app->DB->real_escape_string($this->app->User->GetName()) : 'Cronjob') . "',
     'Stonierung an Shop &uuml;bertragen')"
@@ -2301,7 +2417,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteDeleteFile($shopId, $fileId) {
+    public function RemoteDeleteFile($shopId, $fileId)
+    {
         $inhalt = $this->app->erp->GetDatei($fileId);
         $fileArr = $this->app->DB->SelectRow("SELECT titel,beschreibung FROM datei WHERE id='$fileId' LIMIT 1");
         $titel = $fileArr['titel'];
@@ -2317,8 +2434,10 @@ class Remote {
      * @param int $articleId
      * @param int $shopId
      */
-    public function RemoteUpdateFilesArtikel($articleId, $shopId) {
-        $files = $this->app->DB->SelectArr("SELECT DISTINCT ds.datei 
+    public function RemoteUpdateFilesArtikel($articleId, $shopId)
+    {
+        $files = $this->app->DB->SelectArr(
+            "SELECT DISTINCT ds.datei 
       FROM datei_stichwoerter ds, datei d, artikel a 
       WHERE d.id=ds.datei AND (ds.subjekt='Shopbild' OR ds.subjekt='Gruppenbild') AND ((ds.objekt='Artikel' AND 
       ds.parameter=a.id)  OR (ds.objekt='Kampangen' AND ds.parameter='$shopId')) AND 
@@ -2367,7 +2486,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteSendFile($shopId, $fileId) {
+    public function RemoteSendFile($shopId, $fileId)
+    {
         // sende stichwoerter
         $fileArr = $this->app->DB->SelectRow("SELECT geloescht, titel, beschreibung FROM datei WHERE id='$fileId' LIMIT 1");
         if (empty($fileArr)) {
@@ -2395,9 +2515,11 @@ class Remote {
      *
      * @throws Exception
      */
-    public function RemoteAddFileSubject($shopId, $fileId) {
+    public function RemoteAddFileSubject($shopId, $fileId)
+    {
         // sende stichwoerter
-        $fileList = $this->app->DB->SelectArr("SELECT subjekt, parameter 
+        $fileList = $this->app->DB->SelectArr(
+            "SELECT subjekt, parameter 
       FROM datei_stichwoerter 
       WHERE (objekt='Artikel' OR objekt='Kampangen') AND datei='$fileId'"
         );
@@ -2423,7 +2545,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteDeleteArticle($shopId, $artikel) {
+    public function RemoteDeleteArticle($shopId, $artikel)
+    {
         return $this->RemoteCommand($shopId, 'deletearticle', $artikel);
     }
 
@@ -2434,7 +2557,8 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteSendPartner($shopId, $partner) {
+    public function RemoteSendPartner($shopId, $partner)
+    {
         return $this->RemoteCommand($shopId, 'partnerlist', $partner);
     }
 
@@ -2444,7 +2568,8 @@ class Remote {
      *
      * @return string
      */
-    public function getMethod($obj, $methodname) {
+    public function getMethod($obj, $methodname)
+    {
         $methodname = trim((String) $methodname);
         if ($methodname === '') {
             return '';
@@ -2481,22 +2606,25 @@ class Remote {
      * @return mixed
      * @throws Exception
      */
-    public function RemoteCommand($id, $action, $data = '') {
+    public function RemoteCommand($id, $action, $data = '')
+    {
         $challenge = '';
         $shoptyp = $this->app->DB->Select("SELECT shoptyp FROM shopexport WHERE id='$id' LIMIT 1");
         $modulename = trim($this->app->DB->Select("SELECT modulename FROM shopexport WHERE id='$id' LIMIT 1"), '.');
         $isActionAuth = $action === 'auth';
         $exception = null;
-        
+        $error = null;
+        $ret = null;
+
         $this->logger->debug(
-                'RemoteCommand (Shop '.$id.") ".$action,
-                [
-                    'shop' => $id,
-                    'action' => $action,
-                    'data' => $data
-                ]
+            'RemoteCommand (Shop ' . $id . ") " . $action,
+            [
+                'shop' => $id,
+                'action' => $action,
+                'data' => $data
+            ]
         );
-        
+
         if ($shoptyp === 'custom') {
 
             $error = null;
@@ -2521,7 +2649,8 @@ class Remote {
                                 $method = $this->getMethod($obj, $action);
                                 if (method_exists($obj, $method)) {
                                     $ret = $obj->$method();
-                                     $this->logger->debug('RemoteCommand result (Shop '.$id.') '.$modulename.' '.$action,
+                                    $this->logger->debug(
+                                        'RemoteCommand result (Shop ' . $id . ') ' . $modulename . ' ' . $action,
                                         [
                                             'shop' => $id,
                                             'action' => $action,
@@ -2548,10 +2677,9 @@ class Remote {
                     $error = 'Fehler: Schnittstelle nicht aktiv';
                 }
             } else {
-               $error = 'Fehler: Kein Modul angegeben';
+                $error = 'Fehler: Kein Modul angegeben';
             }
-        }
-        else if ($shoptyp === 'intern') {
+        } else if ($shoptyp === 'intern') {
             if ($modulename != '') {
                 if ($this->app->erp->ModulVorhanden($modulename)) {
                     $obj = $this->app->erp->LoadModul($modulename);
@@ -2571,7 +2699,8 @@ class Remote {
                                     $error = 'Fehler: ' . $e->getMessage();
                                 }
                             }
-                            $this->logger->debug('RemoteCommand result (Shop '.$id.') '.$modulename.' '.$action,
+                            $this->logger->debug(
+                                'RemoteCommand result (Shop ' . $id . ') ' . $modulename . ' ' . $action,
                                 [
                                     'shop' => $id,
                                     'action' => $action,
@@ -2595,21 +2724,22 @@ class Remote {
             } elseif ($isActionAuth) {
                 $error = 'Fehler: Kein Modul vorhanden';
             } else {
-               $error = 'Fehler: Kein Modul angegeben';
+                $error = 'Fehler: Kein Modul angegeben';
             }
         }
         if ($error) {
-            $this->logger->error('RemoteCommand error (Shop '.$id.') '.$modulename.' '.$action,
+            $this->logger->error(
+                'RemoteCommand error (Shop ' . $id . ') ' . $modulename . ' ' . $action,
                 [
                     'error' => $error,
                     'exception' => $exception
                 ]
             );
-            return($error);
-        }            
-        
+            return ($error);
+        }
+
         return $ret;
-   
+
         // Dead code removed here 2024-09-13
     }
 
@@ -2618,7 +2748,8 @@ class Remote {
      * @param int    $id
      * @param string $action
      */
-    public function parseReturn($ret, $id, $action) {
+    public function parseReturn($ret, $id, $action)
+    {
         if ($action === 'getarticlelist') {
             if (empty($ret)) {
                 return;
@@ -2646,7 +2777,8 @@ class Remote {
      * @return mixed|string
      * @throws Exception
      */
-    public function RemoteCommandAES($id, $action, $data = '') {
+    public function RemoteCommandAES($id, $action, $data = '')
+    {
         $challenge = '';
         $shopexport = $this->app->DB->SelectRow("SELECT * FROM shopexport WHERE id='$id' LIMIT 1");
         if (!empty($shopexport)) {
@@ -2672,10 +2804,11 @@ class Remote {
         $post_data['data'] = base64_encode($aes->encrypt(serialize($data)));
 
         if (!$client->post($geturl, $post_data)) {
-            $this->logger->error('An error occurred',
-                    [
-                        'error' => $client->getError()
-                    ]
+            $this->logger->error(
+                'An error occurred',
+                [
+                    'error' => $client->getError()
+                ]
             );
 
             throw new Exception('An error occurred: ' . $client->getError());

--- a/www/pages/shopimporter_woocommerce.php
+++ b/www/pages/shopimporter_woocommerce.php
@@ -1,16 +1,16 @@
 <?php
 /*
-**** COPYRIGHT & LICENSE NOTICE *** DO NOT REMOVE ****
-* 
-* Xentral (c) Xentral ERP Sorftware GmbH, Fuggerstrasse 11, D-86150 Augsburg, * Germany 2019
-*
-* This file is licensed under the Embedded Projects General Public License *Version 3.1. 
-*
-* You should have received a copy of this license from your vendor and/or *along with this file; If not, please visit www.wawision.de/Lizenzhinweis 
-* to obtain the text of the corresponding license version.  
-*
-**** END OF COPYRIGHT & LICENSE NOTICE *** DO NOT REMOVE ****
-*/
+ **** COPYRIGHT & LICENSE NOTICE *** DO NOT REMOVE ****
+ * 
+ * Xentral (c) Xentral ERP Sorftware GmbH, Fuggerstrasse 11, D-86150 Augsburg, * Germany 2019
+ *
+ * This file is licensed under the Embedded Projects General Public License *Version 3.1. 
+ *
+ * You should have received a copy of this license from your vendor and/or *along with this file; If not, please visit www.wawision.de/Lizenzhinweis 
+ * to obtain the text of the corresponding license version.  
+ *
+ **** END OF COPYRIGHT & LICENSE NOTICE *** DO NOT REMOVE ****
+ */
 ?>
 <?php
 use Xentral\Components\Http\JsonResponse;
@@ -56,13 +56,13 @@ class Shopimporter_Woocommerce extends ShopimporterBase
    */
   protected $app;
   protected $dump;
-  
+
   /** @var Logger $logger */
   public $logger;
-  
+
   public function __construct($app, $intern = false)
   {
-    $this->app=$app;
+    $this->app = $app;
     $this->intern = true;
     $this->logger = $app->Container->get('Logger');
   }
@@ -70,7 +70,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
   public function ImportList()
   {
     $msg = $this->app->erp->base64_url_encode('<div class="info">Sie k&ouml;nnen hier die Shops einstellen</div>');
-    header('Location: index.php?module=onlineshops&action=list&msg='.$msg);
+    header('Location: index.php?module=onlineshops&action=list&msg=' . $msg);
     exit;
   }
 
@@ -88,7 +88,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $tmp = $this->CatchRemoteCommand('data');
 
     // Only orders having an order number greater or equal than this should be fetched. null otherwise
-    $number_from = empty($tmp['ab_nummer']) ? null : (int)$tmp['ab_nummer'];
+    $number_from = empty($tmp['ab_nummer']) ? null : (int) $tmp['ab_nummer'];
 
     // pending orders will be fetched into this array. it's length is returned at the end of the funciton
     $pendingOrders = array();
@@ -101,8 +101,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       // ids that are greater than $from_number and use this array with the 'include' property
       // of the WooCommerce API
 
-      $number_to = $number_from+800;
-      if(!empty($tmp['bis_nummer'])){
+      $number_to = $number_from + 800;
+      if (!empty($tmp['bis_nummer'])) {
         $number_to = $tmp['bis_nummer'];
       }
 
@@ -110,20 +110,20 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
       $pendingOrders = $this->client->get('orders', [
         'per_page' => 100,
-        'include' => implode(",",$fakeGreaterThanIds),
+        'include' => implode(",", $fakeGreaterThanIds),
       ]);
 
     } else {
       // fetch posts by status
 
       $pendingOrders = $this->client->get('orders', [
-        'status' => array_map('trim',explode(';', $this->statusPending)),
+        'status' => array_map('trim', explode(';', $this->statusPending)),
         'per_page' => 100
       ]);
 
     }
 
-    return (!empty($pendingOrders)?count($pendingOrders):0);
+    return (!empty($pendingOrders) ? count($pendingOrders) : 0);
   }
 
   /**
@@ -142,7 +142,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $tmp = $this->CatchRemoteCommand('data');
 
     // Only orders having an order number greater or equal than this should be fetched. null otherwise
-    $number_from = empty($tmp['ab_nummer']) ? null : (int)$tmp['ab_nummer'];
+    $number_from = empty($tmp['ab_nummer']) ? null : (int) $tmp['ab_nummer'];
 
     // pending orders will be fetched into this array. it's length is returned at the end of the funciton
     $pendingOrders = array();
@@ -155,8 +155,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       // ids that are greater than $from_number and use this array with the 'include' property
       // of the WooCommerce API
 
-      $number_to = $number_from+800;
-      if(!empty($tmp['bis_nummer'])){
+      $number_to = $number_from + 800;
+      if (!empty($tmp['bis_nummer'])) {
         $number_to = $tmp['bis_nummer'];
       }
 
@@ -164,7 +164,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
       $pendingOrders = $this->client->get('orders', [
         'per_page' => 20,
-        'include' => implode(',',$fakeGreaterThanIds),
+        'include' => implode(',', $fakeGreaterThanIds),
         'order' => 'asc',
         'orderby' => 'id'
       ]);
@@ -173,7 +173,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       // fetch posts by status
 
       $pendingOrders = $this->client->get('orders', [
-        'status' => array_map('trim',explode(';', $this->statusPending)),
+        'status' => array_map('trim', explode(';', $this->statusPending)),
         'per_page' => 20,
         'order' => 'asc',
         'orderby' => 'id'
@@ -182,13 +182,13 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     }
 
     // Return an empty array in case there are no orders to import
-    if ((!empty($pendingOrders)?count($pendingOrders):0) === 0) {
+    if ((!empty($pendingOrders) ? count($pendingOrders) : 0) === 0) {
       return null;
     }
 
     $tmp = [];
 
-    foreach ($pendingOrders as $pendingOrder){
+    foreach ($pendingOrders as $pendingOrder) {
       $wcOrder = $pendingOrder;
       $order = $this->parseOrder($wcOrder);
 
@@ -208,7 +208,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
   // This function searches the wcOrder for the specified WC Meta key
   // and returns it if found, null otherise
-  public function get_wc_meta($wcOrder, $meta_key) {
+  public function get_wc_meta($wcOrder, $meta_key)
+  {
     $value = null;
     foreach ($wcOrder->meta_data as $meta) {
       if ($meta->key == $meta_key) {
@@ -221,7 +222,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
   // Parse the given WooCommerce order, return a Xentral array-represented order.
   // Overload this method whenever additional attributes are required.
-  public function parseOrder($wcOrder) {
+  public function parseOrder($wcOrder)
+  {
 
 
     $order = array();
@@ -238,8 +240,17 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $seperateShippingAddress = !self::compareObjects(
       $wcOrder->billing,
       $wcOrder->shipping,
-      ['first_name', 'second_name', 'company', 'address_1', 'address_2',
-        'city', 'state', 'postcode', 'country']
+      [
+        'first_name',
+        'second_name',
+        'company',
+        'address_1',
+        'address_2',
+        'city',
+        'state',
+        'postcode',
+        'country'
+      ]
     );
 
     if ($isBillingCompany) {
@@ -257,7 +268,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       }
     }
 
-    if(!empty($wcOrder->subshop)){
+    if (!empty($wcOrder->subshop)) {
       $order['subshop'] = $wcOrder->subshop;
     }
 
@@ -265,8 +276,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $order['auftrag'] = $wcOrder->id;
     $order['order'] = json_decode(json_encode($wcOrder), true);
     $order['strasse'] = $wcOrder->billing->address_1;
-    if(!empty($wcOrder->billing->address_2)){
-      $order['adresszusatz'] =  $wcOrder->billing->address_2;
+    if (!empty($wcOrder->billing->address_2)) {
+      $order['adresszusatz'] = $wcOrder->billing->address_2;
     }
     $order['plz'] = $wcOrder->billing->postcode;
     $order['ort'] = $wcOrder->billing->city;
@@ -279,36 +290,36 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $order['onlinebestellnummer'] = $wcOrder->number;
     $order['versandkostenbrutto'] = $wcOrder->shipping_total + $wcOrder->shipping_tax;
     $order['internebemerkung'] = $wcOrder->customer_note;
-    
-    if(!empty((string)$wcOrder->currency)){
-      $warenkorb['waehrung'] = (string)$wcOrder->currency;
+
+    if (!empty((string) $wcOrder->currency)) {
+      $warenkorb['waehrung'] = (string) $wcOrder->currency;
     }
     //
 
     //
     // Coupon Codes
     //
-    $discount_total = (float)$wcOrder->discount_total;
-    $discount_tax = (float)$wcOrder->discount_tax;
+    $discount_total = (float) $wcOrder->discount_total;
+    $discount_tax = (float) $wcOrder->discount_tax;
 
-    if($discount_total != 0) { // Discount was applied to this order
+    if ($discount_total != 0) { // Discount was applied to this order
 
       // Calculate coupon amount
-      if($discount_tax == 0) {
+      if ($discount_tax == 0) {
         // Tax calculations are not enabled for any used coupon
-        $order['rabattnetto'] = -abs((float)$discount_total);
-      } else{
+        $order['rabattnetto'] = -abs((float) $discount_total);
+      } else {
         // At least one used coupon has tax calculations enabled
-        $order['rabattbrutto'] = -abs((float)$discount_total);
-        $order['rabattbrutto'] += -abs((float)$discount_tax);
+        $order['rabattbrutto'] = -abs((float) $discount_total);
+        $order['rabattbrutto'] += -abs((float) $discount_tax);
       }
 
       // Set coupon name
       $couponLine = $wcOrder->coupon_lines;
 
       // Check if we have a valid coupon line just to be sure and set the coupon name
-      if($couponLine && is_array($couponLine) && isset($couponLine[0]) && (String)$couponLine[0]->code !== '') {
-        $order['rabattname'] =  (String)$couponLine[0]->code;
+      if ($couponLine && is_array($couponLine) && isset($couponLine[0]) && (String) $couponLine[0]->code !== '') {
+        $order['rabattname'] = (String) $couponLine[0]->code;
       }
 
     }
@@ -318,8 +329,17 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $seperateShippingAddress = !self::compareObjects(
       $wcOrder->billing,
       $wcOrder->shipping,
-      ['first_name', 'second_name', 'company', 'address_1', 'address_2',
-        'city', 'state', 'postcode', 'country']
+      [
+        'first_name',
+        'second_name',
+        'company',
+        'address_1',
+        'address_2',
+        'city',
+        'state',
+        'postcode',
+        'country'
+      ]
     );
 
     if ($seperateShippingAddress) {
@@ -333,7 +353,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       }
 
       $order['lieferadresse_strasse'] = $wcOrder->shipping->address_1;
-      if(!empty($wcOrder->shipping->address_2)){
+      if (!empty($wcOrder->shipping->address_2)) {
         $order['lieferadresse_adresszusatz'] = $wcOrder->shipping->address_2;
       }
       $order['lieferadresse_plz'] = $wcOrder->shipping->postcode;
@@ -348,7 +368,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       $order['ustid'] = $vatId;
     }
 
-    foreach ($wcOrder->line_items as $wcOrderItem){
+    foreach ($wcOrder->line_items as $wcOrderItem) {
       $order['articlelist'][] = $this->parseItem($wcOrderItem);
     }
 
@@ -358,7 +378,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     return $order;
   }
 
-  function parseItem($wcOrderItem){
+  function parseItem($wcOrderItem)
+  {
     // The WC API doesnt expose the net price of a single product in the get order endpoint.
     // We could query each individual product and get the price, but that would result in a
     // huge amount of HTTP requests.
@@ -367,15 +388,15 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     // this custom calculation as we have access to the exact `total_tax` amount.
     // Passing the net value of the line eliminates rounding issues if the position happens to have large quantites
 
-    switch ($this->priceType){
+    switch ($this->priceType) {
       case 'grosscalculated':
-        $priceValue = ((float)$wcOrderItem->subtotal + (float)$wcOrderItem->subtotal_tax) / (float)$wcOrderItem->quantity;
+        $priceValue = ((float) $wcOrderItem->subtotal + (float) $wcOrderItem->subtotal_tax) / (float) $wcOrderItem->quantity;
         $priceType = 'price';
         break;
       case 'netcalculated':
       default:
         $priceType = 'price_netto';
-        $priceValue = (float)$wcOrderItem->subtotal / (float)$wcOrderItem->quantity;
+        $priceValue = (float) $wcOrderItem->subtotal / (float) $wcOrderItem->quantity;
         break;
     }
 
@@ -387,7 +408,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
     // The item could be a variable product in which case we have to retrieve the sku of the variation product
     if (!empty($wcOrderItem->variation_id)) {
-      $variation_product_sku = $this->getSKUByShopId($wcOrderItem->product_id,$wcOrderItem->variation_id);
+      $variation_product_sku = $this->getSKUByShopId($wcOrderItem->product_id, $wcOrderItem->variation_id);
       if (!empty($variation_product_sku)) {
         $orderItem['articleid'] = $variation_product_sku;
       }
@@ -405,7 +426,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $orderId = $this->CatchRemoteCommand('data')['auftrag'];
 
     if (!empty($orderId)) {
-      $this->client->put('orders/'.$orderId, [
+      $this->client->put('orders/' . $orderId, [
         'status' => $this->statusProcessing,
       ]);
     }
@@ -423,48 +444,50 @@ class Shopimporter_Woocommerce extends ShopimporterBase
   {
     /** @var OrderStatusUpdateRequest $data */
     $data = $this->CatchRemoteCommand('data');
-       
+
     if ($data->orderStatus !== OrderStatus::Completed)
-        return;
+      return;
 
     if (isset($data->shipments)) {
-        $trackingCode = $data->shipments[0]?->trackingNumber;
+      $trackingCode = $data->shipments[0]?->trackingNumber;
     }
 
     if (!empty($trackingCode)) {
-      $this->client->post('orders/'.$data->shopOrderId.'/notes', [
+      $this->client->post('orders/' . $data->shopOrderId . '/notes', [
         'note' => 'Tracking Code: ' . $trackingCode
       ]);
-      
-      $this->logger->info("WooCommerce Tracking Code Rückmeldung für Auftrag: ".$data->orderId,
+
+      $this->logger->info(
+        "WooCommerce Tracking Code Rückmeldung für Auftrag: " . $data->orderId,
         [
-            'orderId' => $data->shopOrderId,
-            'trackingCode' => $trackingCode
+          'orderId' => $data->shopOrderId,
+          'trackingCode' => $trackingCode
         ]
-      );     
+      );
     }
 
     $updateData = [
-        'status' => $this->statusCompleted,
-        'meta_data' => [
-            [
-                'key' => 'tracking_code',
-                'value' => $trackingCode
-            ],
-            [
-                'key' => 'shipping_carrier',
-                'value' => $data->shipments[0]?->shippingMethod
-            ]
-        ],
-    ];
-    $this->client->put('orders/'.$data->shopOrderId, $updateData);
-        
-    $this->logger->info("WooCommerce Statusrückmeldung 'completed' für Auftrag: ".$data->orderId,
+      'status' => $this->statusCompleted,
+      'meta_data' => [
         [
-            'orderId' => $data->shopOrderId,
-            'status' => $this->statusCompleted
+          'key' => 'tracking_code',
+          'value' => $trackingCode
+        ],
+        [
+          'key' => 'shipping_carrier',
+          'value' => $data->shipments[0]?->shippingMethod
         ]
-    );            
+      ],
+    ];
+    $this->client->put('orders/' . $data->shopOrderId, $updateData);
+
+    $this->logger->info(
+      "WooCommerce Statusrückmeldung 'completed' für Auftrag: " . $data->orderId,
+      [
+        'orderId' => $data->shopOrderId,
+        'status' => $this->statusCompleted
+      ]
+    );
     return 'ok';
   }
 
@@ -477,35 +500,34 @@ class Shopimporter_Woocommerce extends ShopimporterBase
   {
     $tmp = $this->CatchRemoteCommand('data');
     $anzahl = 0;
-    $ctmp = (!empty($tmp)?count($tmp):0);
+    $ctmp = (!empty($tmp) ? count($tmp) : 0);
 
-    for($i=0;$i<$ctmp;$i++)
-    {
+    for ($i = 0; $i < $ctmp; $i++) {
       // Get important values from input data
       $artikel = $tmp[$i]['artikel'];
-      if($artikel === 'ignore') {
+      if ($artikel === 'ignore') {
         continue;
       }
       $nummer = $tmp[$i]['nummer'];
-      if(!empty($tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'])){
+      if (!empty($tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'])) {
         $nummer = $tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'];
       }
       $lageranzahl = $tmp[$i]['anzahl_lager'];
       $pseudolager = trim($tmp[$i]['pseudolager']);
       $inaktiv = $tmp[$i]['inaktiv'];
-      $status ='publish';
+      $status = 'publish';
 
       // Do some computations, sanitize input
 
-      if($pseudolager !== ''){
+      if ($pseudolager !== '') {
         $lageranzahl = $pseudolager;
       }
 
-      if($tmp[$i]['ausverkauft']){
+      if ($tmp[$i]['ausverkauft']) {
         $lageranzahl = 0;
       }
 
-      if($inaktiv){
+      if ($inaktiv) {
         $status = 'private';
       }
 
@@ -514,7 +536,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
       if (empty($remoteIdInformation['id'])) {
         // The online shop doesnt know this article, write to log and continue with next product
-        
+
         $this->logger->error("WooCommerce Artikel $nummer wurde im Online-Shop nicht gefunden! Falsche Artikelnummer im Shop hinterlegt?");
         continue;
       }
@@ -526,26 +548,28 @@ class Shopimporter_Woocommerce extends ShopimporterBase
         'stock_quantity' => $lageranzahl
         // WooCommerce doesnt have a standard property for the other values, we're ignoring them
       ];
-      if($remoteIdInformation['isvariant']){
-        $result = $this->client->put('products/' . $remoteIdInformation['parent'].'/variations/'. $remoteIdInformation['id'], $updateProductParams);
-      }else{
+      if ($remoteIdInformation['isvariant']) {
+        $result = $this->client->put('products/' . $remoteIdInformation['parent'] . '/variations/' . $remoteIdInformation['id'], $updateProductParams);
+      } else {
         $result = $this->client->put('products/' . $remoteIdInformation['id'], $updateProductParams);
       }
-      
-      $this->logger->error("WooCommerce Lagerzahlenübertragung für Artikel: $nummer / $remoteIdInformation[id] - Anzahl: $lageranzahl",
+
+      $this->logger->error(
+        "WooCommerce Lagerzahlenübertragung für Artikel: $nummer / $remoteIdInformation[id] - Anzahl: $lageranzahl",
         [
-            'result' => $result
+          'result' => $result
         ]
-      );    
+      );
       $anzahl++;
     }
     return $anzahl;
   }
 
-  public function ImportStorniereAuftrag() {
+  public function ImportStorniereAuftrag()
+  {
     $orderId = $this->CatchRemoteCommand('data')['auftrag'];
     if (!empty($orderId)) {
-      $this->client->put('orders/'.$orderId, [
+      $this->client->put('orders/' . $orderId, [
         'status' => 'cancelled',
       ]);
     } else {
@@ -554,16 +578,17 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     return 'ok';
   }
 
-  public function ImportSendList() {
+  public function ImportSendList()
+  {
     $tmp = $this->catchRemoteCommand('data');
     $anzahl = 0;
     $return = [];
-    for($i=0;$i<(!empty($tmp)?count($tmp):0);$i++){
+    for ($i = 0; $i < (!empty($tmp) ? count($tmp) : 0); $i++) {
       $return[$i] = new ArticleExportResult();
       $artikel = $tmp[$i]['artikel'];
       $return[$i]->articleId = intval($artikel);
       $nummer = $tmp[$i]['nummer'];
-      if(!empty($tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'])){
+      if (!empty($tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'])) {
         $nummer = $tmp[$i]['artikelnummer_fremdnummern'][0]['nummer'];
       }
       $laststock = $tmp[$i]['restmenge'];
@@ -604,31 +629,38 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       $meta_title = $tmp[$i]['metatitle_de'];
 
       $pseudopreis = $tmp[$i]['pseudopreis'];//*1.19;
-      if($pseudopreis <= $preis)$pseudopreis = $preis;
+      if ($pseudopreis <= $preis)
+        $pseudopreis = $preis;
       $steuersatz = $tmp[$i]['steuersatz'];
-      if($steuersatz > 1.10){
+      if ($steuersatz > 1.10) {
         $steuersatz = 'normal';
-      }
-      else{
+      } else {
         $steuersatz = 'ermaessigt';
       }
 
       $lageranzahl = $tmp[$i]['anzahl_lager'];
       $pseudolager = trim($tmp[$i]['pseudolager']);
 
-      if($pseudolager > 0) $lageranzahl=$pseudolager;
-      if($tmp[$i]['ausverkauft']=="1"){
-        $lageranzahl=0; $laststock="1";
+      if ($pseudolager > 0)
+        $lageranzahl = $pseudolager;
+      if ($tmp[$i]['ausverkauft'] == "1") {
+        $lageranzahl = 0;
+        $laststock = "1";
       }
 
-      if($inaktiv)$aktiv=0;
-      else $aktiv=1;
+      if ($inaktiv)
+        $aktiv = 0;
+      else
+        $aktiv = 1;
 
       $product_id = 0;
-      if($laststock!="1") $laststock=0;
+      if ($laststock != "1")
+        $laststock = 0;
 
       $remoteIdInformation = $this->getShopIdBySKU($nummer);
-      $product_id  = $remoteIdInformation['id'];
+      $product_id = $remoteIdInformation['id'] ?? null;
+      $parent_id = $remoteIdInformation['parent'] ?? null;
+      $isVariant = $remoteIdInformation['isvariant'] ?? false;
 
       $commonMetaData = [
         ['key' => '_yoast_wpseo_metadesc', 'value' => $meta_desc],
@@ -640,9 +672,9 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       $commonProductAtts = [
         'name' => $name_de,
         'description' => $description,
-        'status'=>($aktiv?'publish':'private'),
-        'regular_price' => number_format($pseudopreis,2,'.',''),
-        'sale_price' => number_format($preis,2,'.',''),
+        'status' => ($aktiv ? 'publish' : 'private'),
+        'regular_price' => number_format($pseudopreis, 2, '.', ''),
+        'sale_price' => number_format($preis, 2, '.', ''),
         'short_description' => $kurzbeschreibung,
         'weight' => $weight_kg,
         'dimensions' => [
@@ -653,39 +685,61 @@ class Shopimporter_Woocommerce extends ShopimporterBase
         'meta_data' => $commonMetaData,
       ];
 
-      if($lageranzahl===0){
+      if ($lageranzahl === 0) {
         $commonProductAtts['stock_status'] = 'outofstock';
         $commonProductAtts['manage_stock'] = true;
-      }
-      elseif($lageranzahl===''){
+      } elseif ($lageranzahl === '') {
         $commonProductAtts['stock_status'] = 'instock';
         $commonProductAtts['manage_stock'] = false;
-      }
-      else{
+      } else {
         $commonProductAtts['stock_status'] = 'instock';
         $commonProductAtts['manage_stock'] = true;
       }
 
-      if($lageranzahl!=='') {
-        $commonProductAtts['stock_quantity'] = (int)$lageranzahl;
+      if ($lageranzahl !== '') {
+        $commonProductAtts['stock_quantity'] = (int) $lageranzahl;
       }
 
-      if(!is_null($product_id)) {
-        // Such a product already appears to exist, so we update it
-        $this->client->put('products/'.$product_id, array_merge([
+      if (!is_null($product_id)) {
+        // Product exists - check if it's a variation or regular product
+        if ($isVariant && !empty($parent_id)) {
+          // This is a VARIATION - use the variations endpoint
+          // Variations don't support certain attributes (they inherit from parent)
+          $variationAtts = [
+            'regular_price' => $commonProductAtts['regular_price'],
+            'sale_price' => $commonProductAtts['sale_price'],
+            'weight' => $commonProductAtts['weight'],
+            'dimensions' => $commonProductAtts['dimensions'],
+            'stock_status' => $commonProductAtts['stock_status'],
+            'manage_stock' => $commonProductAtts['manage_stock'],
+          ];
+          if (isset($commonProductAtts['stock_quantity'])) {
+            $variationAtts['stock_quantity'] = $commonProductAtts['stock_quantity'];
+          }
+          // Update status: 'publish' for variations is handled differently
+          if (!$aktiv) {
+            $variationAtts['status'] = 'private';
+          }
 
-        ], $commonProductAtts));
+          $this->client->put('products/' . $parent_id . '/variations/' . $product_id, $variationAtts);
 
-        $this->logger->info("WooCommerce Artikel geändert für Artikel: $nummer / $product_id");
-      }
-      else{
+          $this->logger->info("WooCommerce Variante geändert für Artikel: $nummer / Variation: $product_id (Parent: $parent_id)");
+        } else {
+          // This is a regular product
+          $this->client->put('products/' . $product_id, array_merge([
+
+          ], $commonProductAtts));
+
+          $this->logger->info("WooCommerce Artikel geändert für Artikel: $nummer / $product_id");
+        }
+      } else {
         // create a new product
         $product_id = $this->client->post('products/', array_merge([
           'sku' => $nummer,
         ], $commonProductAtts))->id;
         $this->logger->info("WooCommerce neuer Artikel angelegt: $nummer");
       }
-      
+
       // TODO: Kategoriebaum und Bilder werden noch nicht uebertragen
 
       // if(isset($tmp[$i]['kompletter_kategorienbaum'])){
@@ -701,7 +755,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       // Update the associated product categories
 
       $chosenCats = array();
-      if(isset($tmp[$i]['kategorien']) || isset($tmp[$i]['kategoriename'])){
+      if (isset($tmp[$i]['kategorien']) || isset($tmp[$i]['kategoriename'])) {
         $kategorien = $tmp[$i]['kategorien'];
         if (!($kategorien) && !self::emptyString($tmp[$i]['kategoriename'])) {
           $kategorien = array(
@@ -710,26 +764,26 @@ class Shopimporter_Woocommerce extends ShopimporterBase
             )
           );
         }
-        if((!empty($kategorien)?count($kategorien):0)>0){
+        if ((!empty($kategorien) ? count($kategorien) : 0) > 0) {
           // Retrive all WC categories via API
           $allWooCommerceCategories = $this->client->get('products/categories', ['per_page' => '100']);
 
           $searchWpCategories = [];
-          foreach($allWooCommerceCategories as $a){
+          foreach ($allWooCommerceCategories as $a) {
             $searchWpCategories[$a->id] = $a->name;
           }
           // searchWPCategories is an assoc array of type WCCatId(Int) -> WCCatName(string)
 
           // Iterate over the categories that are choosen in xentral
-          foreach($kategorien as $k => $v){
+          foreach ($kategorien as $k => $v) {
             $wawi_cat_name = $v['name'];
 
             $wcCatId = null;
 
             // If WC has a matching category. We match based on name!
-            if(array_search($wawi_cat_name,array_values($searchWpCategories)) !== false) {
+            if (array_search($wawi_cat_name, array_values($searchWpCategories)) !== false) {
               // get  id of that WC Category
-              $wcCatId = array_search($wawi_cat_name,$searchWpCategories);
+              $wcCatId = array_search($wawi_cat_name, $searchWpCategories);
 
             } else {
               // No matching category exists
@@ -741,7 +795,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
             if ($wcCatId) {
               // update category. We first retrieve the product and append the new product category, not replace the entire category array.
-              $alreadyAssignedWCCats = $this->client->get('products/'.$product_id, [
+              $alreadyAssignedWCCats = $this->client->get('products/' . $product_id, [
                 'per_page' => 1,
               ])->categories;
 
@@ -755,12 +809,12 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
               // prepare data to be in correct format for WC api. should be individual items with key 'id' and id as value
               $allCatIdsWCAPIRep = array();
-              foreach($allCatIds as $id) {
+              foreach ($allCatIds as $id) {
                 $allCatIdsWCAPIRep[] = ['id' => $id];
               }
 
               // Update category assignment
-              $this->client->put('products/'.$product_id, [
+              $this->client->put('products/' . $product_id, [
                 'categories' => $allCatIdsWCAPIRep,
               ]);
 
@@ -805,25 +859,28 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $this->data = $data;
 
     $preferences_json = $this->app->DB->Select("SELECT einstellungen_json FROM shopexport WHERE id = '$this->shopid' LIMIT 1");
-    if($preferences_json){
-      $preferences = json_decode($preferences_json,true);
+    $preferences = [];
+    if ($preferences_json) {
+      $preferences = json_decode($preferences_json, true) ?? [];
     }
 
-    $this->protokoll = $preferences['felder']['protokoll'];
-    $this->ssl_ignore = $preferences['felder']['ssl_ignore'];
-    $ImportWooCommerceApiSecret = $preferences['felder']['ImportWoocommerceApiSecret'];
-    $ImportWooCommerceApiKey = $preferences['felder']['ImportWoocommerceApiKey'];
-    $ImportWooCommerceApiUrl = $preferences['felder']['ImportWoocommerceApiUrl'];
+    $felder = $preferences['felder'] ?? [];
 
-    $this->statusPending = $preferences['felder']['statusPending'];
-    $this->statusProcessing = $preferences['felder']['statusProcessing'];
-    $this->statusCompleted = $preferences['felder']['statusCompleted'];
+    $this->protokoll = $felder['protokoll'] ?? null;
+    $this->ssl_ignore = $felder['ssl_ignore'] ?? false;
+    $ImportWooCommerceApiSecret = $felder['ImportWoocommerceApiSecret'] ?? '';
+    $ImportWooCommerceApiKey = $felder['ImportWoocommerceApiKey'] ?? '';
+    $ImportWooCommerceApiUrl = $felder['ImportWoocommerceApiUrl'] ?? '';
 
-    $this->priceType = $preferences['felder']['priceType'];
+    $this->statusPending = $felder['statusPending'] ?? 'pending';
+    $this->statusProcessing = $felder['statusProcessing'] ?? 'processing';
+    $this->statusCompleted = $felder['statusCompleted'] ?? 'completed';
+
+    $this->priceType = $felder['priceType'] ?? null;
 
     $this->url = $ImportWooCommerceApiUrl;
     $this->client = new WCClient(
-    //URL des WooCommerce Rest Servers
+      //URL des WooCommerce Rest Servers
       $ImportWooCommerceApiUrl,
       //WooCommerce API Key
       $ImportWooCommerceApiKey,
@@ -860,13 +917,13 @@ class Shopimporter_Woocommerce extends ShopimporterBase
     $ImportWooCommerceApiSecret = $this->app->Secure->GetPOST('ImportWoocommerceApiSecret');
     $ImportWooCommerceApiUrl = $this->app->Secure->GetPOST('ImportWoocommerceApiUrl');
 
-    if(empty($ImportWooCommerceApiUrl)) {
+    if (empty($ImportWooCommerceApiUrl)) {
       return new JsonResponse(['error' => 'Bitte die API-Url angeben'], JsonResponse::HTTP_BAD_REQUEST);
     }
-    if(empty($ImportWooCommerceApiKey)) {
+    if (empty($ImportWooCommerceApiKey)) {
       return new JsonResponse(['error' => 'Bitte den API-Key angeben'], JsonResponse::HTTP_BAD_REQUEST);
     }
-    if(empty($ImportWooCommerceApiSecret)) {
+    if (empty($ImportWooCommerceApiSecret)) {
       return new JsonResponse(['error' => 'Bitte das API-Secret angeben'], JsonResponse::HTTP_BAD_REQUEST);
     }
     $this->client = new WCClient(
@@ -940,7 +997,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
    * @return array|null The WooCommerce product id of the given product, null if such a product does not exist
    * @throws WCHttpClientException
    */
-  private function getShopIdBySKU($sku) {
+  private function getShopIdBySKU($sku)
+  {
     // Retrieve the product with the given sku.
     // Note: We limit the result set to 1 (per_page=1), so this doesnt work
     // if there are multiple products with the same sku. should not happen in practice anyway
@@ -948,17 +1006,19 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
     // We look at the first product in the array.
     // We may get an empty array, in that case null is returned
-    if (isset($product[0])){
+    if (isset($product[0])) {
       return [
         'id' => $product[0]->id,
         'parent' => $product[0]->parent_id,
-        'isvariant' => !empty($product[0]->parent_id)];
+        'isvariant' => !empty($product[0]->parent_id)
+      ];
     }
 
     return null;
   }
 
-  private function getSKUByShopId($articleid, $variationid) {
+  private function getSKUByShopId($articleid, $variationid)
+  {
     $product = $this->client->get("products/$articleid/variations/$variationid");
 
     // We look at the first product in the array.
@@ -972,19 +1032,20 @@ class Shopimporter_Woocommerce extends ShopimporterBase
   {
     return
       array(
-        'ausblenden'=>array('abholmodus'=>array('zeitbereich')),
-        'archiv'=>array('ab_nummer'),
-        'felder'=>array(
-//          'protokoll'=>array('typ'=>'checkbox','bezeichnung'=>'Protokollierung im Logfile:'),
-          'ssl_ignore'=>array('typ'=>'checkbox','bezeichnung'=>'SSL-Prüfung abschalten:','info' => 'Nur für Testzwecke!'),
-          'ImportWoocommerceApiKey'=>array('typ'=>'text','bezeichnung'=>'{|API Key:','size'=>60),
-          'ImportWoocommerceApiSecret'=>array('typ'=>'text','bezeichnung'=>'{|API Secret|}:','size'=>60),
-          'ImportWoocommerceApiUrl'=>array('typ'=>'text','bezeichnung'=>'{|API Url|}:','size'=>40),
-          'statusPending'=>array('typ'=>'text','bezeichnung'=>'{|Statusname Bestellung offen|}:','size'=>40, 'default' => 'pending', 'info' => '({|ggfs. getrennt durch ";": pending;on-hold|})'),
-          'statusProcessing'=>array('typ'=>'text','bezeichnung'=>'{|Statusname Bestellung in Bearbeitung|}:','size'=>10, 'default' => 'processing'),
-          'statusCompleted'=>array('typ'=>'text','bezeichnung'=>'{|Statusname Bestellung fertig|}:','size'=>10, 'default' => 'completed'),
-          'priceType'=>array('typ'=>'select','bezeichnung'=>'{|Preisberechnungsgrundlage bei Auftragsimport|}','optionen'=>array('netcalculated'=>'{|Nettopreis zurückrechnen (Standard)|}','grosscalculated'=>'{|Bruttopreis zurückrechnen|}')),
-        ));
+        'ausblenden' => array('abholmodus' => array('zeitbereich')),
+        'archiv' => array('ab_nummer'),
+        'felder' => array(
+          //          'protokoll'=>array('typ'=>'checkbox','bezeichnung'=>'Protokollierung im Logfile:'),
+          'ssl_ignore' => array('typ' => 'checkbox', 'bezeichnung' => 'SSL-Prüfung abschalten:', 'info' => 'Nur für Testzwecke!'),
+          'ImportWoocommerceApiKey' => array('typ' => 'text', 'bezeichnung' => '{|API Key:', 'size' => 60),
+          'ImportWoocommerceApiSecret' => array('typ' => 'text', 'bezeichnung' => '{|API Secret|}:', 'size' => 60),
+          'ImportWoocommerceApiUrl' => array('typ' => 'text', 'bezeichnung' => '{|API Url|}:', 'size' => 40),
+          'statusPending' => array('typ' => 'text', 'bezeichnung' => '{|Statusname Bestellung offen|}:', 'size' => 40, 'default' => 'pending', 'info' => '({|ggfs. getrennt durch ";": pending;on-hold|})'),
+          'statusProcessing' => array('typ' => 'text', 'bezeichnung' => '{|Statusname Bestellung in Bearbeitung|}:', 'size' => 10, 'default' => 'processing'),
+          'statusCompleted' => array('typ' => 'text', 'bezeichnung' => '{|Statusname Bestellung fertig|}:', 'size' => 10, 'default' => 'completed'),
+          'priceType' => array('typ' => 'select', 'bezeichnung' => '{|Preisberechnungsgrundlage bei Auftragsimport|}', 'optionen' => array('netcalculated' => '{|Nettopreis zurückrechnen (Standard)|}', 'grosscalculated' => '{|Bruttopreis zurückrechnen|}')),
+        )
+      );
   }
 
   /**
@@ -995,8 +1056,9 @@ class Shopimporter_Woocommerce extends ShopimporterBase
    * @param  array $items [description]
    * @return Bool        [description]
    */
-  protected static function compareObjects($a, $b, $items) {
-    foreach($items as $v) {
+  protected static function compareObjects($a, $b, $items)
+  {
+    foreach ($items as $v) {
       if (property_exists($a, $v) && property_exists($b, $v)) {
         if ($a->$v != $b->$v) {
           //print_r($v);
@@ -1012,7 +1074,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
    * @param  String $string input
    * @return String         output
    */
-  protected static function emptyString($string) {
+  protected static function emptyString($string)
+  {
     return (strlen(trim($string)) == 0);
   }
 
@@ -1031,12 +1094,12 @@ class WCClient
    * @var WCHttpClient
    */
   public $http;
-  
+
   /** @var Logger $logger */
   public $logger;
-  
+
   public $ssl_ignore = false;
-  
+
   /**
    * Initialize client.
    *
@@ -1160,9 +1223,9 @@ class WCResponse
    */
   public function __construct($code = 0, $headers = [], $body = '')
   {
-    $this->code    = $code;
+    $this->code = $code;
     $this->headers = $headers;
-    $this->body    = $body;
+    $this->body = $body;
   }
 
   /**
@@ -1407,11 +1470,11 @@ class WCRequest
    */
   public function __construct($url = '', $method = 'POST', $parameters = [], $headers = [], $body = '')
   {
-    $this->url        = $url;
-    $this->method     = $method;
+    $this->url = $url;
+    $this->method = $method;
     $this->parameters = $parameters;
-    $this->headers    = $headers;
-    $this->body       = $body;
+    $this->headers = $headers;
+    $this->body = $body;
   }
 
   /**
@@ -1607,13 +1670,13 @@ class WCOAuth
     $parameters = [],
     $timestamp = ''
   ) {
-    $this->url            = $url;
-    $this->consumerKey    = $consumerKey;
+    $this->url = $url;
+    $this->consumerKey = $consumerKey;
     $this->consumerSecret = $consumerSecret;
-    $this->apiVersion     = $apiVersion;
-    $this->method         = $method;
-    $this->parameters     = $parameters;
-    $this->timestamp      = $timestamp;
+    $this->apiVersion = $apiVersion;
+    $this->method = $method;
+    $this->parameters = $parameters;
+    $this->timestamp = $timestamp;
   }
 
   /**
@@ -1646,7 +1709,7 @@ class WCOAuth
 
     foreach ($parameters as $key => $value) {
       // Percent symbols (%) must be double-encoded.
-      $key   = $this->encode($key);
+      $key = $this->encode($key);
       $value = $this->encode($value);
 
       $normalized[$key] = $value;
@@ -1711,9 +1774,9 @@ class WCOAuth
     uksort($parameters, 'strcmp');
 
     // Set query string.
-    $queryString  = implode('%26', $this->joinWithEqualsSign($parameters)); // Join with ampersand.
+    $queryString = implode('%26', $this->joinWithEqualsSign($parameters)); // Join with ampersand.
     $stringToSign = $this->method . '&' . $baseRequestUri . '&' . $queryString;
-    $secret       = $this->getSecret();
+    $secret = $this->getSecret();
 
     return base64_encode(hash_hmac(self::HASH_ALGORITHM, $stringToSign, $secret, true));
   }
@@ -1773,9 +1836,9 @@ class WCOAuth
   public function getParameters()
   {
     $parameters = \array_merge($this->parameters, [
-      'oauth_consumer_key'     => $this->consumerKey,
-      'oauth_timestamp'        => $this->timestamp,
-      'oauth_nonce'            => \sha1(\microtime()),
+      'oauth_consumer_key' => $this->consumerKey,
+      'oauth_timestamp' => $this->timestamp,
+      'oauth_nonce' => \sha1(\microtime()),
       'oauth_signature_method' => 'HMAC-' . self::HASH_ALGORITHM,
     ]);
 
@@ -1802,7 +1865,7 @@ class WCHttpClientException extends \Exception
    * @var WCResponse
    */
   private $response;
-  
+
   /**
    * Initialize exception.
    *
@@ -1815,7 +1878,7 @@ class WCHttpClientException extends \Exception
   {
     parent::__construct($message, $code);
 
-    $this->request  = $request;    
+    $this->request = $request;
     $this->response = $response;
   }
 
@@ -1897,10 +1960,10 @@ class WCHttpClient
    * @var string
    */
   private $responseHeaders;
-  
+
   /** @var Logger $logger */
   public $logger;
-  
+
   public $ssl_ignore = false;
 
   /**
@@ -1919,9 +1982,9 @@ class WCHttpClient
       throw new WCHttpClientException('cURL is NOT installed on this server', -1, new WCRequest(), new WCResponse());
     }
 
-    $this->options        = new WCOptions($options);
-    $this->url            = $this->buildApiUrl($url);
-    $this->consumerKey    = $consumerKey;
+    $this->options = new WCOptions($options);
+    $this->url = $this->buildApiUrl($url);
+    $this->consumerKey = $consumerKey;
     $this->consumerSecret = $consumerSecret;
     $this->logger = $logger;
     $this->ssl_ignore = $ssl_ignore;
@@ -1934,7 +1997,7 @@ class WCHttpClient
    */
   protected function isSsl()
   {
-    return strpos($this->url,'https://')===0;
+    return strpos($this->url, 'https://') === 0;
 
   }
 
@@ -1982,7 +2045,7 @@ class WCHttpClient
   {
     // Setup authentication.
     if ($this->isSsl()) {
-      $basicAuth  = new WCBasicAuth(
+      $basicAuth = new WCBasicAuth(
         $this->ch,
         $this->consumerKey,
         $this->consumerSecret,
@@ -1991,7 +2054,7 @@ class WCHttpClient
       );
       $parameters = $basicAuth->getParameters();
     } else {
-      $oAuth      = new WCOAuth(
+      $oAuth = new WCOAuth(
         $url,
         $this->consumerKey,
         $this->consumerSecret,
@@ -2031,7 +2094,7 @@ class WCHttpClient
   protected function getRequestHeaders($sendData = false)
   {
     $headers = [
-      'Accept'     => 'application/json',
+      'Accept' => 'application/json',
       'User-Agent' => $this->options->userAgent() . '/' . WCClient::VERSION,
     ];
 
@@ -2054,8 +2117,8 @@ class WCHttpClient
    */
   protected function createRequest($endpoint, $method, $data = [], $parameters = [])
   {
-    $body    = '';
-    $url     = $this->url . $endpoint;
+    $body = '';
+    $url = $this->url . $endpoint;
     $hasData = !empty($data);
 
     // Setup authentication.
@@ -2089,8 +2152,8 @@ class WCHttpClient
   protected function getResponseHeaders()
   {
     $headers = [];
-    $lines   = explode("\n", $this->responseHeaders);
-    $lines   = array_filter($lines, 'trim');
+    $lines = explode("\n", $this->responseHeaders);
+    $lines = array_filter($lines, 'trim');
 
     foreach ($lines as $index => $line) {
       // Remove HTTP/xxx params.
@@ -2121,8 +2184,8 @@ class WCHttpClient
     });
 
     // Get response data.
-    $body    = curl_exec($this->ch);
-    $code    = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
+    $body = curl_exec($this->ch);
+    $code = curl_getinfo($this->ch, CURLINFO_HTTP_CODE);
     $headers = $this->getResponseHeaders();
 
     // Register response.
@@ -2136,11 +2199,11 @@ class WCHttpClient
    */
   protected function setDefaultCurlSettings()
   {
-    if (!$this->ssl_ignore) {  
-        $verifySsl   = $this->options->verifySsl();
+    if (!$this->ssl_ignore) {
+      $verifySsl = $this->options->verifySsl();
     }
-       
-    $timeout         = $this->options->getTimeout();
+
+    $timeout = $this->options->getTimeout();
     $followRedirects = $this->options->getFollowRedirects();
 
     curl_setopt($this->ch, CURLOPT_SSL_VERIFYPEER, $verifySsl);
@@ -2174,16 +2237,17 @@ class WCHttpClient
 
       if (is_array($errors)) {
         $errorMessage = $errors[0]->message;
-        $errorCode    = $errors[0]->code;
+        $errorCode = $errors[0]->code;
       } elseif (isset($errors->message, $errors->code)) {
         $errorMessage = $errors->message;
-        $errorCode    = $errors->code;
+        $errorCode = $errors->code;
       }
-      
-      $this->logger->error('WooCommerce Error',
+
+      $this->logger->error(
+        'WooCommerce Error',
         [
-            'request' => $this->request,
-            'response' => $this->response
+          'request' => $this->request,
+          'response' => $this->response
         ]
       );
 
@@ -2217,6 +2281,14 @@ class WCHttpClient
     // Test if return a valid JSON.
     if (JSON_ERROR_NONE !== json_last_error()) {
       $message = function_exists('json_last_error_msg') ? json_last_error_msg() : 'Invalid JSON returned';
+      // Log the problematic body for debugging
+      if (isset($this->logger)) {
+        $this->logger->error('JSON Parse Error - Raw Body', [
+          'body_preview' => substr($body, 0, 1000),
+          'body_length' => strlen($body),
+          'json_error' => $message
+        ]);
+      }
       throw new WCHttpClientException(
         sprintf('JSON ERROR: %s', $message),
         $this->response->getCode(),
@@ -2336,11 +2408,11 @@ class WCBasicAuth
    */
   public function __construct($ch, $consumerKey, $consumerSecret, $doQueryString, $parameters = [])
   {
-    $this->ch             = $ch;
-    $this->consumerKey    = $consumerKey;
+    $this->ch = $ch;
+    $this->consumerKey = $consumerKey;
     $this->consumerSecret = $consumerSecret;
-    $this->doQueryString  = $doQueryString;
-    $this->parameters     = $parameters;
+    $this->doQueryString = $doQueryString;
+    $this->parameters = $parameters;
 
     $this->processAuth();
   }
@@ -2351,7 +2423,7 @@ class WCBasicAuth
   protected function processAuth()
   {
     if ($this->doQueryString) {
-      $this->parameters['consumer_key']    = $this->consumerKey;
+      $this->parameters['consumer_key'] = $this->consumerKey;
       $this->parameters['consumer_secret'] = $this->consumerSecret;
     } else {
       \curl_setopt($this->ch, CURLOPT_USERPWD, $this->consumerKey . ':' . $this->consumerSecret);


### PR DESCRIPTION
## Zusammenfassung
Dieser PR behebt den WooCommerce Shop-Importer, um Produktvarianten beim Aktualisieren über die WooCommerce REST API korrekt zu behandeln.
## Problem
Beim Aktualisieren eines Produkts, das in WooCommerce eine **Variante** ist, wurde der falsche API-Endpunkt verwendet:
- ❌ `PUT /products/{varianten_id}` → Gibt 404-Fehler zurück
- ✅ `PUT /products/{parent_id}/variations/{varianten_id}` → Korrekter Endpunkt

## Änderungen
### [www/pages/shopimporter_woocommerce.php](cci:7://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/pages/shopimporter_woocommerce.php:0:0-0:0)
1. **Varianten-Support in [ImportSendList()](cci:1://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/pages/shopimporter_woocommerce.php:556:2-777:3)**
   - Extrahiert `parent_id` und `isvariant` aus dem [getShopIdBySKU()](cci:1://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/pages/shopimporter_woocommerce.php:991:2-1017:3) Ergebnis
   - Verwendet korrekten API-Endpunkt für Varianten: `/products/{parent}/variations/{id}`
   - Sendet nur varianten-geeignete Attribute (Varianten erben Name, Beschreibung etc. vom Elternprodukt)
2. **Null-sichere Konfigurationszugriffe in [getKonfig()](cci:1://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/pages/shopimporter_woocommerce.php:848:2-893:3)**
   - Null-Coalescing-Operatoren (`??`) hinzugefügt, um PHP-Warnings bei fehlenden Konfigurationsschlüsseln zu vermeiden
### [www/lib/class.remote.php](cci:7://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/lib/class.remote.php:0:0-0:0)
3. **Variablen-Initialisierung in [RemoteCommand()](cci:1://file:///c:/Users/3D%20Partner/Documents/OpenXe/OpenXE/www/lib/class.remote.php:2600:4-2743:5)**
   - Initialisiert `$error` und `$ret` am Funktionsanfang
   - Verhindert `PHP Warning: Undefined variable $error`
## Tests
- ✅ Einfache Produkte werden korrekt über `/products/{id}` aktualisiert
- ✅ Varianten werden korrekt über `/products/{parent}/variations/{id}` aktualisiert
- ✅ Lagerbestand-Sync für Varianten funktioniert
- ✅ Keine PHP-Warnings in den Logs