### PR TITLE
Fix sorting of kontoauszuege_list by importdatum

### DIFF
--- a/www/pages/kontoauszuege.php
+++ b/www/pages/kontoauszuege.php
@@ -163,7 +163,7 @@ class Kontoauszuege {
                 $sql = "SELECT SQL_CALC_FOUND_ROWS * FROM ( SELECT 
                             k.id,
                             $dropnbox,
-                            ".$app->erp->FormatDateTimeShort('k.importdatum')." AS importdatum,                            
+                            ".$app->erp->FormatDateTimeShort('k.importdatum')." AS import,                            
                             (SELECT kurzbezeichnung FROM konten WHERE konten.id = k.konto) as kurzbezeichnung,
                             ".$app->erp->FormatDate('k.buchung')." as buchung,                            
                             IF(
@@ -180,6 +180,7 @@ class Kontoauszuege {
                             ".$app->erp->FormatMenge('SUM(fb.betrag)',2)." AS saldo,
                             k.id as menuid,
                             SUM(fb.betrag) AS saldonum,
+                            k.importdatum as importdatum,
                             k.buchung AS buchungdatum
                         FROM kontoauszuege k
                         LEFT JOIN fibu_buchungen_alle fb ON


### PR DESCRIPTION
This fixes the `importdatum` column in `kontoauszuege_list` being sorted by it's string representation (e.g. `24.04.25` was considered newer than `11.02.26`).

Now, the sorting is done on the actual datetime and works as expected.

For reference, see https://github.com/OpenXE-org/OpenXE/pull/175 which did the same for the buchungsdatum.