### PR TITLE
fix pagination of fibu_buchungen_zuordnen by adding missing SQL_CALC_FOUND_ROWS

### DIFF
--- a/www/pages/fibu_buchungen.php
+++ b/www/pages/fibu_buchungen.php
@@ -269,7 +269,7 @@ class Fibu_buchungen {
                     ['sql' => 'salden.id'],
                 );
 
-                $sql = "SELECT
+                $sql = "SELECT SQL_CALC_FOUND_ROWS
                             '' AS dummy,
                             '' AS dummy2,
                             auswahl,


### PR DESCRIPTION
This fixes the broken pagination on the fibu_buchungen_zuordnen page.

Previously, `iFilteredTotal` was just set to the `LIMIT` in `AjaxTablePosition` because of a missing `SQL_CALC_FOUND_ROWS`. Therefore, there was only one page which showed all entries if `LIMIT` was high enough or quietly cut the list off at the `LIMIT`.