### PR TITLE
fix innendienst name with single quotes not being escaped when assigning to an auftrag

### DIFF
--- a/www/lib/class.erpapi.php
+++ b/www/lib/class.erpapi.php
@@ -5491,7 +5491,7 @@ title: 'Abschicken',
       if($sid > 0 && $id > 0)
       {
         $name = $this->app->DB->Select("SELECT name FROM adresse WHERE id='$sid' LIMIT 1");
-        $this->app->DB->Update("UPDATE $table SET bearbeiterid = $sid, bearbeiter='$name' WHERE id='$id' LIMIT 1");
+        $this->app->DB->Update("UPDATE $table SET bearbeiterid = $sid, bearbeiter='".$this->app->DB->real_escape_string($name)."' WHERE id='$id' LIMIT 1");
         header("Location: index.php?module=$table&action=edit&id=$id&cmd=");
         exit;
       }


### PR DESCRIPTION
When assigning Innendienst on an Auftrag, we got an SQL error when `bearbeiter` contained a single quote. This happens regularly with names like `d'artagnan`.

Since creating names containing `'` was not prohibited and names like this are alredy in the Stammdaten, escaping the name we retrieve in `InnendienstAendern` seems like an acceptable fix.