### PR TITLE
variationen Endpunkt korrektur

### DIFF
--- a/www/pages/shopimporter_woocommerce.php
+++ b/www/pages/shopimporter_woocommerce.php
@@ -726,9 +726,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
           $this->logger->info("WooCommerce Variante geändert für Artikel: $nummer / Variation: $product_id (Parent: $parent_id)");
         } else {
           // This is a regular product
-          $this->client->put('products/' . $product_id, array_merge([
-
-          ], $commonProductAtts));
+          $this->client->put('products/' . $product_id, $commonProductAtts);
 
           $this->logger->info("WooCommerce Artikel geändert für Artikel: $nummer / $product_id");
         }
@@ -753,6 +751,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       // }
 
       // Update the associated product categories
+      // For variations, categories belong to the parent product
+      $category_product_id = ($remoteIdInformation['isvariant']) ? $remoteIdInformation['parent'] : $product_id;
 
       $chosenCats = array();
       if (isset($tmp[$i]['kategorien']) || isset($tmp[$i]['kategoriename'])) {
@@ -795,7 +795,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
 
             if ($wcCatId) {
               // update category. We first retrieve the product and append the new product category, not replace the entire category array.
-              $alreadyAssignedWCCats = $this->client->get('products/' . $product_id, [
+              $alreadyAssignedWCCats = $this->client->get('products/' . $category_product_id, [
                 'per_page' => 1,
               ])->categories;
 
@@ -814,7 +814,7 @@ class Shopimporter_Woocommerce extends ShopimporterBase
               }
 
               // Update category assignment
-              $this->client->put('products/' . $product_id, [
+              $this->client->put('products/' . $category_product_id, [
                 'categories' => $allCatIdsWCAPIRep,
               ]);
 

--- a/www/pages/shopimporter_woocommerce.php
+++ b/www/pages/shopimporter_woocommerce.php
@@ -549,17 +549,43 @@ class Shopimporter_Woocommerce extends ShopimporterBase
         // WooCommerce doesnt have a standard property for the other values, we're ignoring them
       ];
       if ($remoteIdInformation['isvariant']) {
+        // This is a variation — update via parent/variations endpoint
         $result = $this->client->put('products/' . $remoteIdInformation['parent'] . '/variations/' . $remoteIdInformation['id'], $updateProductParams);
-      } else {
-        $result = $this->client->put('products/' . $remoteIdInformation['id'], $updateProductParams);
-      }
 
-      $this->logger->error(
-        "WooCommerce Lagerzahlenübertragung für Artikel: $nummer / $remoteIdInformation[id] - Anzahl: $lageranzahl",
-        [
-          'result' => $result
-        ]
-      );
+        $this->logger->error(
+          "WooCommerce Lagerzahlenübertragung für Variante: $nummer / $remoteIdInformation[id] (Parent: $remoteIdInformation[parent]) - Anzahl: $lageranzahl",
+          ['result' => $result]
+        );
+      } elseif ($remoteIdInformation['type'] === 'variable') {
+        // This is a variable parent product — stock must be set on each variation individually
+        $variations = $this->client->get('products/' . $remoteIdInformation['id'] . '/variations', ['per_page' => 100]);
+
+        if (!empty($variations)) {
+          foreach ($variations as $variation) {
+            $result = $this->client->put(
+              'products/' . $remoteIdInformation['id'] . '/variations/' . $variation->id,
+              $updateProductParams
+            );
+
+            $this->logger->error(
+              "WooCommerce Lagerzahlenübertragung für Variante von variablem Produkt: $nummer / Variation: $variation->id (Parent: $remoteIdInformation[id]) - Anzahl: $lageranzahl",
+              ['result' => $result]
+            );
+          }
+        } else {
+          $this->logger->error(
+            "WooCommerce variables Produkt $nummer / $remoteIdInformation[id] hat keine Variationen — Lager-Sync übersprungen"
+          );
+        }
+      } else {
+        // Simple product — direct update
+        $result = $this->client->put('products/' . $remoteIdInformation['id'], $updateProductParams);
+
+        $this->logger->error(
+          "WooCommerce Lagerzahlenübertragung für Artikel: $nummer / $remoteIdInformation[id] - Anzahl: $lageranzahl",
+          ['result' => $result]
+        );
+      }
       $anzahl++;
     }
     return $anzahl;
@@ -1010,7 +1036,8 @@ class Shopimporter_Woocommerce extends ShopimporterBase
       return [
         'id' => $product[0]->id,
         'parent' => $product[0]->parent_id,
-        'isvariant' => !empty($product[0]->parent_id)
+        'isvariant' => !empty($product[0]->parent_id),
+        'type' => $product[0]->type ?? 'simple'
       ];
     }
 


### PR DESCRIPTION
 Zusammenfassung                                                                                                                                                                    
  WooCommerce-Produktexport schlug mit 404-Fehler fehl, wenn Produktvarianten aktualisiert werden sollten. Die WC REST API erfordert für Varianten den Endpunkt                   
  /products/{parent_id}/variations/{id} statt /products/{id}.
  
  Änderungen

  - Produkt-Update: Varianten werden jetzt über den korrekten Variations-Endpunkt aktualisiert. Dabei werden nur die für Varianten relevanten Attribute (Preis, Gewicht, Maße,    
  Lagerbestand, Status) übertragen — Name, Beschreibung etc. werden vom Parent vererbt.
  - Kategorie-Sync: Kategorien gehören in WooCommerce zum Parent-Produkt, nicht zur Variante. GET und PUT für Kategoriezuweisungen verwenden jetzt die Parent-ID bei Varianten.   
  - Lager-Sync hatte diese Logik bereits korrekt implementiert — die Produktdaten- und Kategorie-Synchronisation ist nun gleichgezogen.

  Hintergrund

  Betroffen waren alle Varianten-Artikel beim Shop-Export. Einfache Produkte waren nicht betroffen. Die Fehlermeldung von WooCommerce war:
  ▎ Um Produktvarianten zu bearbeiten, sollten Sie den Endpunkt /products/<product_id>/variations/<id> verwenden.