### PR TITLE
fix: write tracking to versandpakete table for UI visibility (#247)

### DIFF
--- a/classes/Modules/Api/Controller/Version1/TrackingNumberController.php
+++ b/classes/Modules/Api/Controller/Version1/TrackingNumberController.php
@@ -69,6 +69,31 @@ class TrackingNumberController extends AbstractController
         ];
         $result = $resource->insert($bindValues);
 
+        // Also write to versandpakete table so tracking appears in UI Pakete tab
+        // The UI reads exclusively from versandpakete (old versand-based display is commented out)
+        $DB = $this->legacyApi->app->DB;
+        $lieferscheinId = (int)$orderData['lieferscheinid'];
+        if ($lieferscheinId > 0) {
+            $versandart = $DB->Select(
+                "SELECT versandart FROM lieferschein WHERE id = '" . $lieferscheinId . "' LIMIT 1"
+            );
+            $DB->Insert(
+                "INSERT INTO versandpakete (tracking, tracking_link, gewicht, status, lieferschein_ohne_pos, versandart, versender) "
+                . "VALUES ("
+                . "'" . $DB->real_escape_string($input['tracking']) . "', "
+                . "'', "
+                . "'" . $DB->real_escape_string($input['gewicht']) . "', "
+                . "'versendet', "
+                . "'" . $lieferscheinId . "', "
+                . "'" . $DB->real_escape_string($versandart) . "', "
+                . "'API'"
+                . ")"
+            );
+            $DB->Update(
+                "UPDATE lieferschein SET versand_status = 1 WHERE id = '" . $lieferscheinId . "'"
+            );
+        }
+
         return $this->sendResult($result, Response::HTTP_CREATED);
     }
 

--- a/classes/Modules/Api/Controller/Version1/TrackingNumberController.php
+++ b/classes/Modules/Api/Controller/Version1/TrackingNumberController.php
@@ -80,12 +80,12 @@ class TrackingNumberController extends AbstractController
             $DB->Insert(
                 "INSERT INTO versandpakete (tracking, tracking_link, gewicht, status, lieferschein_ohne_pos, versandart, versender) "
                 . "VALUES ("
-                . "'" . $DB->real_escape_string($input['tracking']) . "', "
+                . "'" . $DB->real_escape_string((string)$input['tracking']) . "', "
                 . "'', "
-                . "'" . $DB->real_escape_string($input['gewicht']) . "', "
+                . "'" . $DB->real_escape_string((string)$input['gewicht']) . "', "
                 . "'versendet', "
                 . "'" . $lieferscheinId . "', "
-                . "'" . $DB->real_escape_string($versandart) . "', "
+                . "'" . $DB->real_escape_string((string)$versandart) . "', "
                 . "'API'"
                 . ")"
             );


### PR DESCRIPTION
## Summary

- API tracking creation (`POST /v1/trackingnummern`) now also writes to the `versandpakete` table
- Sets `lieferschein.versand_status = 1` so the Pakete tab shows the tracking

## Problem

The API wrote tracking numbers only to the legacy `versand` table, but the UI Pakete tab reads exclusively from `versandpakete`. Tracking created via API was invisible in the UI.

## Root Cause

The old `versand`-based display in `lieferschein.php` was replaced with the new `versandpakete`-based system, but the REST API was never updated to match.

| | API (before fix) | UI | API (after fix) |
|---|---|---|---|
| Writes to `versand` | Yes | No | Yes (backward compat) |
| Writes to `versandpakete` | **No** | Yes | **Yes** |
| Sets `versand_status` | No | Yes | **Yes** |

## Changes

`classes/Modules/Api/Controller/Version1/TrackingNumberController.php`:
- After existing `versand` INSERT, also INSERT into `versandpakete` with `lieferschein_ohne_pos` link
- Sets `lieferschein.versand_status = 1`

## Test plan

- [ ] Create tracking via API — verify it appears in UI Pakete tab
- [ ] Create tracking via UI — verify unchanged behavior
- [ ] Verify `versand` table still gets the entry (backward compat)

Fixes #247