### PR TITLE
fix: Sidebar-Counter für Wiedervorlagen reaktivieren

### DIFF
--- a/www/eproosystem.php
+++ b/www/eproosystem.php
@@ -410,10 +410,10 @@ class erpooSystem extends Application
               'link' => 'index.php?module=aufgaben&action=list',
               'counter' => $this->erp->AnzahlOffeneAufgaben()
           ],
-/*          'Wiedervorlage' => [
+          'Wiedervorlage' => [
               'link' => 'index.php?module=wiedervorlage&action=list',
               'counter' => $resubmissionCount,
-          ],*/
+          ],
           'Kalender' => [
               'link' => 'index.php?module=kalender&action=list',
               'counter' => $appointmentCount

--- a/www/eproosystem.php
+++ b/www/eproosystem.php
@@ -381,6 +381,7 @@ class erpooSystem extends Application
           $appointmentCount=0;
       }
 
+      $resubmissionCount = 0;
       if($this->erp->ModulVorhanden('wiedervorlage') && $this->erp->RechteVorhanden('wiedervorlage','list')) {
         $resubmissionCount = (int)$this->DB->Select(
           sprintf(


### PR DESCRIPTION
## Summary
- Reactivates the sidebar counter for overdue Wiedervorlagen (resubmissions/reminders)
- The SQL query, permission checks (`wiedervorlage:list`), project rights filter, and badge rendering were already fully functional — only the menu entry in `$possibleUserItems` was commented out
- Single 4-line change in `www/eproosystem.php`: remove `/*` and `*/` around the `'Wiedervorlage'` array entry

Fixes #250

## Test plan
- [ ] Sidebar shows Wiedervorlage icon with badge counter
- [ ] Counter shows only overdue Wiedervorlagen assigned to the logged-in user
- [ ] Counter updates when Wiedervorlagen are completed or new ones become overdue
- [ ] Entry only appears for users with `wiedervorlage:list` permission
- [ ] Click navigates to `index.php?module=wiedervorlage&action=list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)