### PR TITLE
Bugfix Versandarten foreach null when module is not loaded

### DIFF
--- a/www/pages/versandarten.php
+++ b/www/pages/versandarten.php
@@ -181,7 +181,7 @@ class Versandarten {
         $error[] = sprintf('Versandart "%s" existiert nicht.', $form['selmodul']); */
 
       $obj = $this->loadModule($form['modul'], $id);
-      $module_errors = $obj?->getErrors();
+      $module_errors = $obj?->getErrors() ?? [];
       foreach ($module_errors as $module_error) {
           $this->app->Tpl->addMessage('error', $module_error);
       }
@@ -245,7 +245,7 @@ class Versandarten {
     $this->app->Tpl->Set('AKTMODUL', $daten['modul']);
 
     $obj = $this->loadModule($daten['modul'], $daten['id']);
-    $module_errors = $obj?->getErrors();
+    $module_errors = $obj?->getErrors() ?? [];
     foreach ($module_errors as $module_error) {
         $this->app->Tpl->addMessage('error', $module_error);
     }


### PR DESCRIPTION
Closes #258

## Problem

Beim Anlegen einer Versandart ohne Modul crasht die Edit-Seite mit `TypeError: foreach() argument must be of type array|object, null given` unter PHP 8.

## Ursache

Commit 8d84eb8 hat `$obj->getErrors()` durch den Nullsafe-Operator `$obj?->getErrors()` ersetzt. Wenn `$obj` null ist, liefert der Ausdruck aber `null`, nicht `[]` — das anschließende `foreach` crasht dann unter PHP 8.

## Fix

Ergänzt `?? []` an beiden betroffenen Stellen in `www/pages/versandarten.php`, damit `foreach` immer ein Array erhält.

## Test

1. Neue Versandart über "Versandart ohne Modul anlegen" erstellen → Edit-Seite öffnet jetzt sauber
2. Bestehende Versandart mit Modul (z. B. DHL) bearbeiten → funktioniert weiterhin