### PR TITLE
feat(mahnwesen): expose {FRIST}, {DATUMRECHNUNG}, {MAHNDATUM}, {TAGE} placeholders

### DIFF
--- a/www/pages/mahnwesen.php
+++ b/www/pages/mahnwesen.php
@@ -675,7 +675,12 @@ class Mahnwesen {
 
           $offen = $this->app->erp->GetSaldoDokument($rechnung_id, 'rechnung');
 
-          if($tage <=0) $tage = 0;
+          $tage = max(0, (int)$rechnungarr['mahn_tage']);
+
+          $mahnwesen_datum_valid = !empty($mahnwesen_datum) && $mahnwesen_datum !== '0000-00-00';
+          $frist_de = $mahnwesen_datum_valid
+              ? date('d.m.Y', strtotime($mahnwesen_datum.' +'.$tage.' days'))
+              : '';
 
 /*          $datummahnung= $this->app->DB->Select("SELECT DATE_FORMAT(DATE_ADD('$mahnwesen_datum', INTERVAL $tage DAY),'%d.%m.%Y')");
           $datumrechnungzahlungsziel= $this->app->DB->Select("SELECT DATE_FORMAT(DATE_ADD('$datum_sql', INTERVAL $zahlungszieltage DAY),'%d.%m.%Y')");
@@ -726,6 +731,10 @@ class Mahnwesen {
             'rechnung' => $belegnr,
             'belegnr' => $belegnr,
             'datum' => $datum_sql,
+            'datumrechnung' => $datum_sql,
+            'frist' => $frist_de,
+            'mahndatum' => $mahnwesen_datum_deutsch,
+            'tage' => $tage,
             'offen' => $this->app->erp->EUR(-$offen['betrag'])." ".$offen['waehrung'],
             'mahngebuehr' => $this->app->erp->EUR($rechnungarr['mahn_gebuehr']),
             'heute' => $rechnungarr['heute']

--- a/www/pages/mahnwesen.php
+++ b/www/pages/mahnwesen.php
@@ -566,6 +566,7 @@ class Mahnwesen {
                     r.*,
                     ".$this->app->erp->FormatDate('datum')." datum,
                     ".$this->app->erp->FormatDate('CURRENT_DATE')." heute,
+                    IF(r.mahnwesen_datum != '0000-00-00', ".$this->app->erp->FormatDate('r.mahnwesen_datum').", '') mahnwesen_datum_de,
                     m.name as mahn_name,
                     m.tage as mahn_tage,
                     m.gebuehr as mahn_gebuehr,
@@ -678,9 +679,8 @@ class Mahnwesen {
           $tage = max(0, (int)$rechnungarr['mahn_tage']);
 
           $mahnwesen_datum_valid = !empty($mahnwesen_datum) && $mahnwesen_datum !== '0000-00-00';
-          $frist_de = $mahnwesen_datum_valid
-              ? date('d.m.Y', strtotime($mahnwesen_datum.' +'.$tage.' days'))
-              : '';
+          $fristTs = $mahnwesen_datum_valid ? strtotime($mahnwesen_datum.' +'.$tage.' days') : false;
+          $frist_de = $fristTs === false ? '' : date('d.m.Y', $fristTs);
 
 /*          $datummahnung= $this->app->DB->Select("SELECT DATE_FORMAT(DATE_ADD('$mahnwesen_datum', INTERVAL $tage DAY),'%d.%m.%Y')");
           $datumrechnungzahlungsziel= $this->app->DB->Select("SELECT DATE_FORMAT(DATE_ADD('$datum_sql', INTERVAL $zahlungszieltage DAY),'%d.%m.%Y')");
@@ -733,7 +733,7 @@ class Mahnwesen {
             'datum' => $datum_sql,
             'datumrechnung' => $datum_sql,
             'frist' => $frist_de,
-            'mahndatum' => $mahnwesen_datum_deutsch,
+            'mahndatum' => $mahnwesen_datum_deutsch ?? '',
             'tage' => $tage,
             'offen' => $this->app->erp->EUR(-$offen['betrag'])." ".$offen['waehrung'],
             'mahngebuehr' => $this->app->erp->EUR($rechnungarr['mahn_gebuehr']),


### PR DESCRIPTION
Closes #270

## Summary

- Erweitert das Platzhalter-Mapping in `MahnwesenMessage()` um `{FRIST}`, `{DATUMRECHNUNG}`, `{MAHNDATUM}`, `{TAGE}` — Werte stammen aus den System-Einstellungen → Mahnwesen (`mahnwesen.tage`) und der `rechnung`-Tabelle.
- Ersetzt das No-op `if(\$tage<=0)\$tage=0;` (Use-before-define) durch eine saubere Zuweisung `\$tage = max(0, (int)\$rechnungarr['mahn_tage'])`.
- Berechnet `{FRIST}` PHP-seitig (`date('d.m.Y', strtotime(...))`) statt DB-Roundtrip.
- Guard für `0000-00-00` als Reset-Sentinel von `mahnwesen_datum`.

## Diff

```diff
@@ -675,7 +675,12 @@ class Mahnwesen {
           \$offen = \$this->app->erp->GetSaldoDokument(\$rechnung_id, 'rechnung');
 
-          if(\$tage <=0) \$tage = 0;
+          \$tage = max(0, (int)\$rechnungarr['mahn_tage']);
+
+          \$mahnwesen_datum_valid = !empty(\$mahnwesen_datum) && \$mahnwesen_datum !== '0000-00-00';
+          \$frist_de = \$mahnwesen_datum_valid
+              ? date('d.m.Y', strtotime(\$mahnwesen_datum.' +'.\$tage.' days'))
+              : '';
@@ -726,6 +731,10 @@ class Mahnwesen {
             'datum' => \$datum_sql,
+            'datumrechnung' => \$datum_sql,
+            'frist' => \$frist_de,
+            'mahndatum' => \$mahnwesen_datum_deutsch,
+            'tage' => \$tage,
```

## Code-Review

Drei Codex-Review-Runden durchlaufen:
- Runde 1: Drei Blocker identifiziert (\$datum_sql ist bereits deutsch, \$tage nicht definiert, 0000-00-00-Guard fehlt) → adressiert
- Runde 2: Use-before-define an Zeile 678 → adressiert (Konsolidierung an einer Stelle)
- Runde 3: GO

## Test plan

- [ ] In den System-Einstellungen → Mahnwesen für eine Mahnstufe Tage und Gebühr setzen
- [ ] Briefpapier-Vorlage z.B. mit `Frist bis zum {FRIST}` editieren
- [ ] Mahnung manuell auslösen
- [ ] Verifizieren: `{FRIST}` ist im versendeten Brief korrekt durch `mahnwesen_datum + Tage` ersetzt (deutsches Format dd.mm.yyyy)
- [ ] Verifizieren: Andere bestehende Platzhalter (`{DATUM}`, `{OFFEN}`, `{MAHNGEBUEHR}`) funktionieren weiterhin
- [ ] Edge-Case: Rechnung mit `mahnwesen_datum = '0000-00-00'` → `{FRIST}` bleibt leer statt unsinniges Datum

## Out of scope

- Der parallele SQL-Injection-Bug in `DokumentCreate` (Escaping in `class.erpapi.php:16041`) wird in diesem PR nicht behandelt.
- Deutscher Hinweistext in `geschaeftsbrief_vorlagen.tpl` für die neuen Platzhalter — kann in Folge-PR ergänzt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)